### PR TITLE
feat: Cria model de order e adiciona página de geração do pedido

### DIFF
--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -1,5 +1,6 @@
 class CartItemsController < ApplicationController
   before_action :get_user_id, except: :destroy
+  before_action :authenticate_user!, except: :create
   
   def index
     @cart = CartItem.where(user_id: @user_id, order_id: nil)

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -2,7 +2,7 @@ class CartItemsController < ApplicationController
   before_action :get_user_id, except: :destroy
   
   def index
-    @cart = CartItem.where(user_id: @user_id)
+    @cart = CartItem.where(user_id: @user_id, order_id: nil)
   end
 
   def create 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,7 @@
 class OrdersController < ApplicationController
   before_action :get_user, only: [:index, :new, :create]
   before_action :get_cart_and_sum, only: [:new, :create]
+  before_action :authenticate_user!
 
   def index
     @orders = Order.where(user_id: @user_id) 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -12,4 +12,31 @@ class OrdersController < ApplicationController
     end
     @order = Order.new
   end
+
+  def show
+    @order = Order.find(params[:id])
+    @cart = @order.cart_items
+    @sum = 0
+    @cart.each do |ci| 
+      @sum += ci.product.prices
+                .where('validity_start <= ?', DateTime.current)
+                .order(validity_start: :asc)
+                .last
+                .price_in_brl * ci.quantity
+    end
+  end
+  
+  def create
+    @order_params = params.require(:order).permit(:address, :user_id)
+    @order = Order.new(@order_params)
+    if @order.save
+      CartItem.where(order_id: nil).each {|ci| ci.update(order_id: @order.id)}
+      flash[:notice] = "Pedido efetuado com sucesso"
+      redirect_to @order
+    else
+      flash[:alert] = "Falha ao efetuar o pedido"
+      render 'new'
+    end
+  end
+  
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,20 +1,12 @@
 class OrdersController < ApplicationController
-  before_action :get_user, only: [:index, :new]
+  before_action :get_user, only: [:index, :new, :create]
+  before_action :get_cart_and_sum, only: [:new, :create]
 
   def index
     @orders = Order.where(user_id: @user_id) 
   end
   
   def new
-    @cart = CartItem.where(user_id: @user_id, order_id: nil)
-    @sum = 0
-    @cart.each do |ci| 
-      @sum += ci.product.prices
-                .where('validity_start <= ?', DateTime.current)
-                .order(validity_start: :asc)
-                .last
-                .price_in_brl * ci.quantity
-    end
     @order = Order.new
   end
 
@@ -43,5 +35,17 @@ class OrdersController < ApplicationController
 
   def get_user
     @user_id = params[:user_id]
+  end
+
+  def get_cart_and_sum
+    @cart = CartItem.where(user_id: @user_id, order_id: nil)
+    @sum = 0
+    @cart.each do |ci| 
+      @sum += ci.product.prices
+                .where('validity_start <= ?', DateTime.current)
+                .order(validity_start: :asc)
+                .last
+                .price_in_brl * ci.quantity
+    end
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,15 @@
+class OrdersController < ApplicationController
+  def new
+    @user_id = params[:user_id]
+    @cart = CartItem.where(user_id: @user_id, order_id: nil)
+    @sum = 0
+    @cart.each do |ci| 
+      @sum += ci.product.prices
+                .where('validity_start <= ?', DateTime.current)
+                .order(validity_start: :asc)
+                .last
+                .price_in_brl * ci.quantity
+    end
+    @order = Order.new
+  end
+end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
   def show
     @product = Product.find_by(id: params[:id])
+    @cart_item = CartItem.new
     return redirect_to root_path, alert: 'Produto não encontrado' if @product.nil?
     @current_price = @product.prices
                              .where('validity_start <= ?', DateTime.current)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   def show
     @product = Product.find_by(id: params[:id])
-    @cart_item = CartItem.new
+    
     return redirect_to root_path, alert: 'Produto não encontrado' if @product.nil?
     return redirect_to root_path, alert: 'Produto não encontrado' unless admin_signed_in? || @product.on_shelf?
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
-  # primary_abstract_class
+  primary_abstract_class
 
   self.abstract_class = true
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,9 @@
 class ApplicationRecord < ActiveRecord::Base
-  primary_abstract_class
+  # primary_abstract_class
+
+  self.abstract_class = true
+
+  def self.human_enum_name(enum_name, enum_value)
+    I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}")
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,3 @@
+class Order < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,8 @@
 class Order < ApplicationRecord
   belongs_to :user
   has_many :cart_items
+  validates_presence_of :address
+  validate :must_have_cart
 
   before_create :set_code
   after_create :process_cart
@@ -22,5 +24,9 @@ class Order < ApplicationRecord
                                      .last
                                      .price_in_brl)
     end
+  end
+
+  def must_have_cart
+    return errors.add(:pedido, 'deve possuir carrinho.') if CartItem.where(order_id: nil, user: self.user).empty?
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,11 +2,25 @@ class Order < ApplicationRecord
   belongs_to :user
   has_many :cart_items
 
-  before_validation :set_code, on: :create
+  before_create :set_code
+  after_create :process_cart
+
+  enum status: {pending: 0, approved: 5, canceled: 9}
   
   private
 
   def set_code
     self.code = SecureRandom.alphanumeric(8).upcase.insert(4, '-')
+  end
+
+  def process_cart
+    CartItem.where(order_id: nil, user: self.user).each do |ci|
+      ci.update(order_id: self.id)
+      ci.update(price_on_purchase: ci.product.prices
+                                     .where('validity_start <= ?', DateTime.current)
+                                     .order(validity_start: :asc)
+                                     .last
+                                     .price_in_brl)
+    end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,3 +1,12 @@
 class Order < ApplicationRecord
   belongs_to :user
+  has_many :cart_items
+
+  before_validation :set_code, on: :create
+  
+  private
+
+  def set_code
+    self.code = SecureRandom.alphanumeric(8).upcase.insert(4, '-')
+  end
 end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,5 +1,5 @@
 class ApplicationService
-  def self.get_branches(*args, &blocks)
-    new(*args, &blocks).get_branches
+  def self.process_cart(*args, &blocks)
+    new(*args, &blocks).process_cart
   end
 end

--- a/app/views/cart_items/index.html.erb
+++ b/app/views/cart_items/index.html.erb
@@ -1,29 +1,33 @@
 <h3 class='text-center'>Meu Carrinho</h3>
 
-<table class="table text-center align-middle m-auto" style="max-width: 900px">
-  <thead>
-    <tr>
-      <th>Produto</th>
-      <th>Quantidade</th>
-      <th>Preço</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @cart.each do |ci|%>
+<% if @cart.empty?%>
+  <strong>Adicione um produto ao carrinho!</strong>
+<% else %>
+  <table class="table text-center align-middle m-auto" style="max-width: 900px">
+    <thead>
       <tr>
-        <td class="text-start"> <%= link_to ci.product.name, product_path(ci.product.id) %></td>
-        <td class="text-center"> <strong> <%=ci.quantity%>  </strong></td> 
-        <td class="text-center"> <strong> <%=number_to_currency(ci.product.prices
-                                               .where('validity_start <= ?', DateTime.current)
-                                               .order(validity_start: :asc)
-                                               .last
-                                               .price_in_brl, precision: 2)%> </strong></td>
-        <td><%= button_to 'Retirar', cart_item_path(ci.id), class: 'btn btn-outline-warning mini-button', method: :delete %> </td>
+        <th>Produto</th>
+        <th>Quantidade</th>
+        <th>Preço</th>
       </tr>
-    <%end%>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @cart.each do |ci|%>
+        <tr>
+          <td class="text-start"> <%= link_to ci.product.name, product_path(ci.product.id) %></td>
+          <td class="text-center"> <strong> <%=ci.quantity%>  </strong></td> 
+          <td class="text-center"> <strong> <%=number_to_currency(ci.product.prices
+                                                .where('validity_start <= ?', DateTime.current)
+                                                .order(validity_start: :asc)
+                                                .last
+                                                .price_in_brl, precision: 2)%> </strong></td>
+          <td><%= button_to 'Retirar', cart_item_path(ci.id), class: 'btn btn-outline-warning mini-button', method: :delete %> </td>
+        </tr>
+      <%end%>
+    </tbody>
+  </table>
 
-<div class="text-center buffer">
-  <%= link_to 'Finalizar Pedido', new_user_order_path(@cart.last.user_id), class: 'btn btn-outline-primary mini-button' %>
-</div>
+  <div class="text-center buffer">
+    <%= link_to 'Finalizar Pedido', new_user_order_path(@cart.last.user_id), class: 'btn btn-outline-primary mini-button' %>
+  </div>
+<% end %>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -42,6 +42,10 @@
         <li class="nav-link">
           <%= link_to 'Meu Carrinho', user_cart_items_path(current_user.id), class: 'text-light text-decoration-none' %>
         </li>
+        
+        <li class="nav-link">
+          <%= link_to 'Meus Pedidos', user_orders_path(current_user.id), class: 'text-light text-decoration-none' %>
+        </li>
 
         <li class="nav-link">
           <%= button_to 'Sair', destroy_user_session_path, method: :delete, class: 'btn btn-light mini-button' %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,5 @@
+<% @orders.each do |o|%>
+  <div>
+    Pedido <%= link_to o.code, order_path(o.id) %> - <%=I18n.t "order_status.#{o.status}"%>
+  </div>
+<%end%>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,5 +1,5 @@
 <% @orders.each do |o|%>
   <div>
-    Pedido <%= link_to o.code, order_path(o.id) %> - <%=I18n.t "order_status.#{o.status}"%>
+    Pedido <%= link_to o.code, order_path(o.id) %> - <%= Order.human_enum_name(:status, o.status)%>
   </div>
 <%end%>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,5 +1,11 @@
-<% @orders.each do |o|%>
-  <div>
-    Pedido <%= link_to o.code, order_path(o.id) %> - <%= Order.human_enum_name(:status, o.status)%>
-  </div>
-<%end%>
+<% if @orders.empty? %>
+  <p class='text center'>
+    <strong> Você ainda não possui nenhum pedido. </strong>
+  </p>
+<% else %>
+  <% @orders.each do |o|%>
+    <div>
+      Pedido <%= link_to o.code, order_path(o.id) %> - <%= Order.human_enum_name(:status, o.status)%>
+    </div>
+  <%end%>
+<% end %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,4 +1,5 @@
 <h3 class='text-center'>Meu Pedido</h3>
+
 <table class="table text-center align-middle m-auto" style="max-width: 900px">
   <thead>
     <tr>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,5 +1,4 @@
-<h3 class='text-center'>Meu Carrinho</h3>
-
+<h3 class='text-center'>Meu Pedido</h3>
 <table class="table text-center align-middle m-auto" style="max-width: 900px">
   <thead>
     <tr>
@@ -21,9 +20,23 @@
         <td><%= button_to 'Retirar', cart_item_path(ci.id), class: 'btn btn-outline-warning mini-button', method: :delete %> </td>
       </tr>
     <%end%>
+    <tr>
+      <td></td>
+      <td class="text-center"> <strong>Valor Total:</strong></td>
+      <td class="text-center"> <strong><%=number_to_currency(@sum)%></strong></td>
+    </tr>
   </tbody>
 </table>
 
-<div class="text-center buffer">
-  <%= link_to 'Finalizar Pedido', new_user_order_path(@cart.last.user_id), class: 'btn btn-outline-primary mini-button' %>
+<div class="text center standard-width m-auto">
+  <%= simple_form_for @order, url: user_orders_path(@user_id) do |cat| %>
+    <%= cat.input :address %>
+    <div class="text-center little-buffer">
+      <%= cat.button :submit, 'Confirmar', class: 'btn btn-warning' %>
+    </div>
+  <% end %>
+
+  <div class="text-center buffer">
+    <%= link_to 'Voltar', user_cart_items_path(@user_id), class: 'btn btn-outline-primary mini-button' %>
+  </div>
 </div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,4 +1,4 @@
-<h3 class='text-center'>Meu Pedido</h3>
+<h3 class='text-center'>Pedido <%=@order.code%></h3>
 <table class="table text-center align-middle m-auto" style="max-width: 900px">
   <thead>
     <tr>
@@ -26,8 +26,8 @@
       <td class="text-center"> <strong><%=@order.address%></strong></td>
     </tr>
     <tr>
-      <td colspan="2" class="text-center"> <strong>Pedido</strong></td>
-      <td class="text-center"> <strong><%=@order.code%></strong></td>
+      <td colspan="2" class="text-center"> <strong><%=Order.human_attribute_name(:status)%>:</strong></td>
+      <td class="text-center"> <strong><%=Order.human_enum_name(:status, @order.status)%></strong></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -25,19 +25,13 @@
       <td class="text-center"> <strong>Valor Total:</strong></td>
       <td class="text-center"> <strong><%=number_to_currency(@sum)%></strong></td>
     </tr>
+    <tr>
+      <td colspan="2" class="text-center"> <strong>Endereço de entrega:</strong></td>
+      <td class="text-center"> <strong><%=@order.address%></strong></td>
+    </tr>
+    <tr>
+      <td colspan="2" class="text-center"> <strong>Pedido</strong></td>
+      <td class="text-center"> <strong><%=@order.code%></strong></td>
+    </tr>
   </tbody>
 </table>
-
-<div class="text center standard-width m-auto">
-  <%= simple_form_for @order, url: user_orders_path(@user_id) do |cat| %>
-    <%= cat.input :address %>
-    <%= cat.input :user_id, :as => :hidden, :input_html => {value: @user_id} %>
-    <div class="text-center little-buffer">
-      <%= cat.button :submit, 'Confirmar', class: 'btn btn-warning' %>
-    </div>
-  <% end %>
-
-  <div class="text-center buffer">
-    <%= link_to 'Voltar', user_cart_items_path(@user_id), class: 'btn btn-outline-primary mini-button' %>
-  </div>
-</div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -13,7 +13,6 @@
         <td class="text-start"> <%= link_to ci.product.name, product_path(ci.product.id) %></td>
         <td class="text-center"> <strong> <%=ci.quantity%>  </strong></td> 
         <td class="text-center"> <strong> <%=number_to_currency(ci.price_on_purchase, precision: 2)%> </strong></td>
-        <td><%= button_to 'Retirar', cart_item_path(ci.id), class: 'btn btn-outline-warning mini-button', method: :delete %> </td>
       </tr>
     <%end%>
     <tr>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -12,11 +12,7 @@
       <tr>
         <td class="text-start"> <%= link_to ci.product.name, product_path(ci.product.id) %></td>
         <td class="text-center"> <strong> <%=ci.quantity%>  </strong></td> 
-        <td class="text-center"> <strong> <%=number_to_currency(ci.product.prices
-                                               .where('validity_start <= ?', DateTime.current)
-                                               .order(validity_start: :asc)
-                                               .last
-                                               .price_in_brl, precision: 2)%> </strong></td>
+        <td class="text-center"> <strong> <%=number_to_currency(ci.price_on_purchase, precision: 2)%> </strong></td>
         <td><%= button_to 'Retirar', cart_item_path(ci.id), class: 'btn btn-outline-warning mini-button', method: :delete %> </td>
       </tr>
     <%end%>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -16,7 +16,7 @@
   <%user_id = user_signed_in? ? current_user.id : user_id = 0%>  
   <%= form_with url: user_cart_items_path(user_id) do |f|%>
     <%= f.label :quantity, 'Quantidade'%>
-    <%= f.number_field :quantity%>
+    <%= f.number_field :quantity, min: 1, value: 1%>
     <%= f.hidden_field :product_id, value: @product.id%>
     <%= f.submit 'Adicionar ao carrinho'%>
   <%end%>

--- a/config/locales/models/cart_item_pt-BR.yml
+++ b/config/locales/models/cart_item_pt-BR.yml
@@ -1,0 +1,9 @@
+pt-BR:
+  activerecord:
+    models:
+      cart_item:
+        one: Item
+        other: Carrinho
+    attributes:
+      cart_item:
+        quantity: Quantidade

--- a/config/locales/models/order_pt-BR.yml
+++ b/config/locales/models/order_pt-BR.yml
@@ -7,7 +7,7 @@ pt-BR:
     attributes:
       order:
         address: Endereço de entrega
-  order_status:
-    pending: Pendente
-    approved: Aprovado
-    canceled: Cancelado
+        statuses:
+          pending: Pendente
+          approved: Aprovado
+          canceled: Cancelado

--- a/config/locales/models/order_pt-BR.yml
+++ b/config/locales/models/order_pt-BR.yml
@@ -7,3 +7,7 @@ pt-BR:
     attributes:
       order:
         address: Endereço de entrega
+  order_status:
+    pending: Pendente
+    approved: Aprovado
+    canceled: Cancelado

--- a/config/locales/models/order_pt-BR.yml
+++ b/config/locales/models/order_pt-BR.yml
@@ -1,0 +1,9 @@
+pt-BR:
+  activerecord:
+    models:
+      order:
+        one: Pedido
+        other: Pedidos
+    attributes:
+      order:
+        address: Endereço de entrega

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,6 @@ Rails.application.routes.draw do
 
   resources :users, shallow: true do
     resources :cart_items, only: [:index, :create, :destroy]
-    resources :orders, only: [:show, :new, :create]
+    resources :orders, only: [:index, :show, :new, :create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,6 @@ Rails.application.routes.draw do
 
   resources :users, shallow: true do
     resources :cart_items, only: [:create, :index, :destroy]
+    resources :orders, only: [:new, :create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :product_categories, only: [:index, :show, :new, :create, :edit, :update]
 
   resources :users, shallow: true do
-    resources :cart_items, only: [:create, :index, :destroy]
-    resources :orders, only: [:new, :create]
+    resources :cart_items, only: [:index, :create, :destroy]
+    resources :orders, only: [:show, :new, :create]
   end
 end

--- a/db/migrate/20220615205221_create_orders.rb
+++ b/db/migrate/20220615205221_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220615205713_add_order_to_cart_items.rb
+++ b/db/migrate/20220615205713_add_order_to_cart_items.rb
@@ -1,0 +1,5 @@
+class AddOrderToCartItems < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :cart_items, :order, foreign_key: true
+  end
+end

--- a/db/migrate/20220615224648_add_code_to_order.rb
+++ b/db/migrate/20220615224648_add_code_to_order.rb
@@ -1,0 +1,5 @@
+class AddCodeToOrder < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :code, :string
+  end
+end

--- a/db/migrate/20220616234014_add_status_to_order.rb
+++ b/db/migrate/20220616234014_add_status_to_order.rb
@@ -1,0 +1,5 @@
+class AddStatusToOrder < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :status, :integer
+  end
+end

--- a/db/migrate/20220617003446_add_price_on_purchase_to_cart_items.rb
+++ b/db/migrate/20220617003446_add_price_on_purchase_to_cart_items.rb
@@ -1,0 +1,5 @@
+class AddPriceOnPurchaseToCartItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cart_items, :price_on_purchase, :decimal
+  end
+end

--- a/db/migrate/20220617121724_add_default_value_to_orders_status.rb
+++ b/db/migrate/20220617121724_add_default_value_to_orders_status.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueToOrdersStatus < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :orders, :status, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_15_224648) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_17_003446) do
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_15_224648) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "order_id"
+    t.decimal "price_on_purchase"
     t.index ["order_id"], name: "index_cart_items_on_order_id"
     t.index ["product_id"], name: "index_cart_items_on_product_id"
     t.index ["user_id"], name: "index_cart_items_on_user_id"
@@ -42,6 +43,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_15_224648) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "code"
+    t.integer "status"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_17_003446) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_17_121724) do
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -43,7 +43,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_17_003446) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "code"
-    t.integer "status"
+    t.integer "status", default: 0
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
@@ -58,10 +58,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_17_003446) do
 
   create_table "product_categories", force: :cascade do |t|
     t.string "name"
+    t.integer "product_category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "ancestry"
     t.index ["ancestry"], name: "index_product_categories_on_ancestry"
+    t.index ["product_category_id"], name: "index_product_categories_on_product_category_id"
   end
 
   create_table "products", force: :cascade do |t|
@@ -91,4 +93,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_17_003446) do
   add_foreign_key "cart_items", "users"
   add_foreign_key "orders", "users"
   add_foreign_key "prices", "products"
+  add_foreign_key "product_categories", "product_categories"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_15_205713) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_15_224648) do
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -41,6 +41,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_15_205713) do
     t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "code"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_14_201118) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_15_205713) do
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -30,8 +30,18 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_14_201118) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "order_id"
+    t.index ["order_id"], name: "index_cart_items_on_order_id"
     t.index ["product_id"], name: "index_cart_items_on_product_id"
     t.index ["user_id"], name: "index_cart_items_on_user_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "prices", force: :cascade do |t|
@@ -73,7 +83,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_14_201118) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "cart_items", "orders"
   add_foreign_key "cart_items", "products"
   add_foreign_key "cart_items", "users"
+  add_foreign_key "orders", "users"
   add_foreign_key "prices", "products"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,8 @@
 Price.destroy_all
 ProductCategory.destroy_all
 Product.destroy_all
+CartItem.destroy_all
+Order.destroy_all
 User.destroy_all
 Admin.destroy_all
 
@@ -60,9 +62,12 @@ moveis = ProductCategory.create(name: "Móveis")
 mesa_escritorio = ProductCategory.create(name: "Mesa de Escritório", parent: moveis)
 guarda_roupa = ProductCategory.create(name: "Guarda-roupa", parent: moveis)
 
-# Create Carts
-CartItem.create!(product: Product.first, quantity: 5, user: user )
-CartItem.create!(product: Product.last, quantity: 7, user: user )
+# Create Carts and Orders
+CartItem.create!(product: product1, quantity: 5, user: user )
+CartItem.create!(product: product2, quantity: 7, user: user )
+Order.create!(address: 'Rua da entrega, 75', user: user)
+CartItem.create!(product: product3, quantity: 5, user: user )
+CartItem.create!(product: product1, quantity: 7, user: user )
 
 
 p "Foram criados #{Admin.count} admins"
@@ -70,4 +75,5 @@ p "Foram criados #{User.count} usuários"
 p "Foram criados #{Product.count} produtos"
 p "Foram criados um total de #{Price.count} preços para #{Price.select(:product_id).distinct.count} produtos"
 p "Foram criadas #{ProductCategory.count} categorias de produtos"
-p "Foram criadas #{CartItem.count} instâncias de carrinho"
+p "Foram criadas #{CartItem.count} instâncias de item de carrinho"
+p "Foram criadas #{Order.count} instâncias de pedidos"

--- a/spec/factories/cart_items.rb
+++ b/spec/factories/cart_items.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :cart_item do
     product
     user
+    order_id { nil }
     quantity { 1 }
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :order do
-    user { nil }
-    address { "MyString" }
+    user 
+    address { "Rua da Entrega, 54" }
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :order do
+    user { nil }
+    address { "MyString" }
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,5 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Order, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#valid?' do
+    it {should belong_to(:user)}
+    it {should have_many(:cart_items)}
+    it {should validate_presence_of(:address)}
+
+    context 'regarding the cart' do
+      it "must have a cart" do
+        order = build(:order)
+
+        expect(order.valid?).to be false
+        expect(order.errors.full_messages).to include 'Pedido deve possuir carrinho.' 
+      end
+
+      it "has a cart" do
+        user = create(:user)
+        product = create(:product)
+        create(:price, product: product)
+        create(:cart_item, user: user, product: product)
+        order = build(:order, user: user)
+
+        expect(order.valid?).to be true
+      end
+    end
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -6,22 +6,22 @@ RSpec.describe Order, type: :model do
     it {should have_many(:cart_items)}
     it {should validate_presence_of(:address)}
 
-    context 'regarding the cart' do
-      it "must have a cart" do
+    context 'when cart' do
+      it "doesn't exist gives false" do
         order = build(:order)
 
-        expect(order.valid?).to be false
+        expect(order.valid?).to be_falsey
         expect(order.errors.full_messages).to include 'Pedido deve possuir carrinho.' 
       end
 
-      it "has a cart" do
+      it "exists gives true" do
         user = create(:user)
         product = create(:product)
         create(:price, product: product)
         create(:cart_item, user: user, product: product)
         order = build(:order, user: user)
 
-        expect(order.valid?).to be true
+        expect(order).to be_truthy
       end
     end
   end

--- a/spec/system/order/user_cart_view_spec.rb
+++ b/spec/system/order/user_cart_view_spec.rb
@@ -7,7 +7,13 @@ describe 'User enters cart page' do
     product_1 = create(:product, name: 'Caneca')
     product_2 = create(:product, name: 'Garrafa', sku: 'GRF9933')
     product_3 = create(:product, name: 'Jarra', sku: 'JRA68755')
-    create(:product, name: 'Pote', sku: 'PTE68755')
+    product_4 = create(:product, name: 'Pote', sku: 'PTE68755')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1, price_in_brl: "11.99")
+      create(:price, product: product_2, price_in_brl: "4.99")
+      create(:price, product: product_3, price_in_brl: "15.99")
+      create(:price, product: product_4, price_in_brl: "2.99")
+    end
     create(:cart_item, product: product_1, quantity: 3, user: user)
     create(:cart_item, product: product_2, quantity: 7, user: user)
     create(:cart_item, product: product_3, quantity: 5, user: user_2)
@@ -16,11 +22,11 @@ describe 'User enters cart page' do
     visit root_path
     click_on "Meu Carrinho"
     
-    expect(page).to have_content "Produto Quantidade"
-    expect(page).to have_content "Caneca 3"
-    expect(page).to have_content "Garrafa 7"
-    expect(page).not_to have_content "Jarra 5"
-    expect(page).not_to have_content "Pote"
+    expect(page).to have_content "Produto Quantidade Preço"
+    expect(page).to have_content "Caneca 3 R$ 11,99"
+    expect(page).to have_content "Garrafa 7 R$ 4,99"
+    expect(page).not_to have_content "Jarra 5 R$ 15,99"
+    expect(page).not_to have_content "Pote 7 R$ 2,99"
   end
   
   it 'after adding a product' do
@@ -29,7 +35,9 @@ describe 'User enters cart page' do
     product_2 = create(:product, name: 'Garrafa', sku: 'GRF9933')
     product_3 = create(:product, name: 'Jarra', sku: 'JRA68755')
     Timecop.freeze(1.month.ago) do
-      create(:price, product: product_3)
+      create(:price, product: product_1, price_in_brl: "11.99")
+      create(:price, product: product_2, price_in_brl: "4.99")
+      create(:price, product: product_3, price_in_brl: "15.99")
     end
     create(:cart_item, product: product_1, quantity: 3, user:  user)
     create(:cart_item, product: product_2, quantity: 7, user:  user)
@@ -41,10 +49,9 @@ describe 'User enters cart page' do
     click_on "Adicionar ao carrinho"
     click_on "Meu Carrinho"
     
-    expect(page).to have_content "Produto Quantidade"
-    expect(page).to have_content "Caneca 3"
-    expect(page).to have_content "Garrafa 7"
-    expect(page).to have_content "Jarra 5"
+    expect(page).to have_content "Caneca"
+    expect(page).to have_content "Garrafa"
+    expect(page).to have_content "Jarra"
   end
 
   it 'and withdraws an item ' do
@@ -52,6 +59,11 @@ describe 'User enters cart page' do
     product_1 = create(:product, name: 'Caneca')
     product_2 = create(:product, name: 'Garrafa', sku: 'GRF9933')
     product_3 = create(:product, name: 'Jarra', sku: 'JRA68755')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1, price_in_brl: "11.99")
+      create(:price, product: product_2, price_in_brl: "4.99")
+      create(:price, product: product_3, price_in_brl: "15.99")
+    end
     create(:cart_item, product: product_1, quantity: 3, user: user)
     create(:cart_item, product: product_2, quantity: 7, user: user)
     create(:cart_item, product: product_3, quantity: 5, user: user)
@@ -64,10 +76,11 @@ describe 'User enters cart page' do
     end
     
     expect(page).to have_content "Produto retirado: Caneca."
-    expect(page).to have_content "Produto Quantidade"
-    expect(page).not_to have_content "Caneca 3"
-    expect(page).to have_content "Garrafa 7"
-    expect(page).to have_content "Jarra 5"
+    within('tbody') do
+      expect(page).not_to have_content "Caneca"
+    end
+    expect(page).to have_content "Garrafa"
+    expect(page).to have_content "Jarra"
   end
 
   it 'and enters product page through cart link' do

--- a/spec/system/order/user_cart_view_spec.rb
+++ b/spec/system/order/user_cart_view_spec.rb
@@ -29,7 +29,7 @@ describe 'User enters cart page' do
     expect(page).not_to have_content "Pote 7 R$ 2,99"
   end
 
-  it 'and there is no cart items' do
+  it 'and there are no cart items' do
     user = create(:user)
     user_2 = create(:user, name: 'Jaime', email: 'jaime@meuemail.com')
     product_1 = create(:product, name: 'Jarra', sku: 'JRA68755')

--- a/spec/system/order/user_cart_view_spec.rb
+++ b/spec/system/order/user_cart_view_spec.rb
@@ -28,6 +28,27 @@ describe 'User enters cart page' do
     expect(page).not_to have_content "Jarra 5 R$ 15,99"
     expect(page).not_to have_content "Pote 7 R$ 2,99"
   end
+
+  it 'and there is no cart items' do
+    user = create(:user)
+    user_2 = create(:user, name: 'Jaime', email: 'jaime@meuemail.com')
+    product_1 = create(:product, name: 'Jarra', sku: 'JRA68755')
+    product_2 = create(:product, name: 'Pote', sku: 'PTE68755')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1, price_in_brl: "15.99")
+      create(:price, product: product_2, price_in_brl: "2.99")
+    end
+    create(:cart_item, product: product_1, quantity: 7, user: user_2)
+    create(:cart_item, product: product_2, quantity: 5, user: user_2)
+
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meu Carrinho"
+    
+    expect(page).to have_content "Adicione um produto ao carrinho!"
+    expect(page).not_to have_content "Jarra 5 R$ 15,99"
+    expect(page).not_to have_content "Pote 7 R$ 2,99"
+  end
   
   it 'after adding a product' do
     user = create(:user)

--- a/spec/system/order/user_confirms_order_spec.rb
+++ b/spec/system/order/user_confirms_order_spec.rb
@@ -30,4 +30,36 @@ describe "User confirms order from cart" do
     expect(page).to have_button "Confirmar" 
     expect(page).to have_link "Voltar"
   end
+
+  it "and generates order" do
+    user = create(:user)
+    product_1 = create(:product, name: 'Caneca')
+    product_2 = create(:product, name: 'Garrafa', sku: 'GRF9933')
+    product_3 = create(:product, name: 'Jarra', sku: 'JRA68755')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1, price_in_brl: "11.99")
+      create(:price, product: product_2, price_in_brl: "4.99")
+      create(:price, product: product_3, price_in_brl: "15.99")
+    end
+    create(:cart_item, product: product_1, quantity: 3, user: user)
+    create(:cart_item, product: product_2, quantity: 7, user: user)
+    create(:cart_item, product: product_3, quantity: 5, user: user)
+    allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('123ASD45')
+
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meu Carrinho"
+    click_on "Finalizar Pedido"
+    fill_in "Endereço de entrega", with: "Rua da entrega, 45"
+    click_on "Confirmar"
+
+    expect(page).to have_content 'Pedido 123A-SD45'
+    expect(page).to have_content "Produto Quantidade Preço"
+    expect(page).to have_content "Caneca 3 R$ 11,99"
+    expect(page).to have_content "Garrafa 7 R$ 4,99"
+    expect(page).to have_content "Jarra 5 R$ 15,99"
+    expect(page).to have_content "Valor Total: R$ 150,85"
+    expect(page).to have_content "Endereço de entrega: Rua da entrega, 45" 
+    expect(page).to have_link "Voltar"
+  end
 end

--- a/spec/system/order/user_confirms_order_spec.rb
+++ b/spec/system/order/user_confirms_order_spec.rb
@@ -60,6 +60,7 @@ describe "User confirms order from cart" do
     expect(page).to have_content "Jarra 5 R$ 15,99"
     expect(page).to have_content "Valor Total: R$ 150,85"
     expect(page).to have_content "Endereço de entrega: Rua da entrega, 45" 
+    expect(page).to have_content "Status: Pendente"
     expect(page).to have_link "Voltar"
   end
 end

--- a/spec/system/order/user_confirms_order_spec.rb
+++ b/spec/system/order/user_confirms_order_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe "User confirms order from cart" do
+  it "and sees order generate page" do
+    user = create(:user)
+    product_1 = create(:product, name: 'Caneca')
+    product_2 = create(:product, name: 'Garrafa', sku: 'GRF9933')
+    product_3 = create(:product, name: 'Jarra', sku: 'JRA68755')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1, price_in_brl: "11.99")
+      create(:price, product: product_2, price_in_brl: "4.99")
+      create(:price, product: product_3, price_in_brl: "15.99")
+    end
+    create(:cart_item, product: product_1, quantity: 3, user: user)
+    create(:cart_item, product: product_2, quantity: 7, user: user)
+    create(:cart_item, product: product_3, quantity: 5, user: user)
+
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meu Carrinho"
+    click_on "Finalizar Pedido"
+    
+    expect(page).to have_content "Meu Pedido"
+    expect(page).to have_content "Produto Quantidade Preço"
+    expect(page).to have_content "Caneca 3 R$ 11,99"
+    expect(page).to have_content "Garrafa 7 R$ 4,99"
+    expect(page).to have_content "Jarra 5 R$ 15,99"
+    expect(page).to have_content "Valor Total: R$ 150,85"
+    expect(page).to have_field "Endereço de entrega" 
+    expect(page).to have_button "Confirmar" 
+    expect(page).to have_link "Voltar"
+  end
+end

--- a/spec/system/order/user_confirms_order_spec.rb
+++ b/spec/system/order/user_confirms_order_spec.rb
@@ -58,9 +58,29 @@ describe "User confirms order from cart" do
     expect(page).to have_content "Caneca 3 R$ 11,99"
     expect(page).to have_content "Garrafa 7 R$ 4,99"
     expect(page).to have_content "Jarra 5 R$ 15,99"
+    expect(page).not_to have_button "Retirar"
     expect(page).to have_content "Valor Total: R$ 150,85"
     expect(page).to have_content "Endereço de entrega: Rua da entrega, 45" 
     expect(page).to have_content "Status: Pendente"
     expect(page).to have_link "Voltar"
+  end
+
+  it "and fails to generate order" do
+    user = create(:user)
+    product_1 = create(:product, name: 'Caneca')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1)
+    end
+    create(:cart_item, product: product_1, quantity: 3, user: user)
+    allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('123ASD45')
+
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meu Carrinho"
+    click_on "Finalizar Pedido"
+    fill_in "Endereço de entrega", with: ""
+    click_on "Confirmar"
+
+    expect(page).to have_content "Endereço de entrega não pode ficar em branco"
   end
 end

--- a/spec/system/order/user_view_order_details_spec.rb
+++ b/spec/system/order/user_view_order_details_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'User enters order detail page' do
+  it "and sees prices set on date of purchase" do
+    user = create(:user)
+    product = create(:product, name: 'Caneca')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product, price_in_brl: "11.99")
+      create(:price, product: product, price_in_brl: "4.99", validity_start: 15.days.from_now)
+    end
+    Timecop.freeze(20.days.ago) do
+      create(:cart_item, product: product, quantity: 3, user: user)
+      @order_1 = create(:order, user: user, status: 'pending')
+    end
+    
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meus Pedidos"
+    click_on "#{@order_1.code}"
+
+    expect(page).to have_content "R$ 11,99"
+    expect(page).to have_content "Valor Total: R$ 35,97"
+  end
+end

--- a/spec/system/order/user_view_orders_spec.rb
+++ b/spec/system/order/user_view_orders_spec.rb
@@ -46,4 +46,14 @@ describe "User enters orders page" do
     expect(page).to have_content "R$ 11,99"
     expect(page).to have_content "Valor Total: R$ 35,97"
   end
+
+  it "and there is no orders" do
+    user = create(:user)
+    
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meus Pedidos"
+
+    expect(page).to have_content "Você ainda não possui nenhum pedido."
+  end
 end

--- a/spec/system/order/user_view_orders_spec.rb
+++ b/spec/system/order/user_view_orders_spec.rb
@@ -26,28 +26,7 @@ describe "User enters orders page" do
     expect(page).not_to have_content "Pedido #{order_3.code} - Pendente"
   end
 
-  it "and enters a order page after some time" do
-    user = create(:user)
-    product = create(:product, name: 'Caneca')
-    Timecop.freeze(1.month.ago) do
-      create(:price, product: product, price_in_brl: "11.99")
-      create(:price, product: product, price_in_brl: "4.99", validity_start: 15.days.from_now)
-    end
-    Timecop.freeze(20.days.ago) do
-      create(:cart_item, product: product, quantity: 3, user: user)
-      @order_1 = create(:order, user: user, status: 'pending')
-    end
-    
-    login_as(user, scope: :user)
-    visit root_path
-    click_on "Meus Pedidos"
-    click_on "#{@order_1.code}"
-
-    expect(page).to have_content "R$ 11,99"
-    expect(page).to have_content "Valor Total: R$ 35,97"
-  end
-
-  it "and there is no orders" do
+  it "and there are no orders" do
     user = create(:user)
     
     login_as(user, scope: :user)

--- a/spec/system/order/user_view_orders_spec.rb
+++ b/spec/system/order/user_view_orders_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe "User enters orders page" do
+  it "and views own orders" do
+    user = create(:user)
+    user_2 = create(:user, name: 'Maciel', email: 'maciel@meuemail.com')
+    product_1 = create(:product, name: 'Caneca')
+    product_2 = create(:product, name: 'Garrafa', sku: 'GRF9933')
+    product_3 = create(:product, name: 'Jarra', sku: 'JRA68755')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1, price_in_brl: "11.99")
+      create(:price, product: product_2, price_in_brl: "4.99")
+      create(:price, product: product_3, price_in_brl: "15.99")
+    end
+    order_1 = create(:order, user: user, status: 'pending')
+    order_2 = create(:order, user: user, status: 'aproved')
+    order_3 = create(:order, user: user_2, status: 'pending')
+    create(:cart_item, product: product_1, quantity: 3, user: user, order: order_1)
+    create(:cart_item, product: product_2, quantity: 7, user: user, order: order_2)
+    create(:cart_item, product: product_3, quantity: 5, user: user_2, order: order_3)
+
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meus Pedidos"
+
+    expect(page).to have_content "Pedido  #{order_1.code} - Pendente"
+    expect(page).to have_content "Pedido  #{order_2.code} - Aprovado"
+  end
+end


### PR DESCRIPTION
## Issues: #14, #30, #29, #28, #27, #26.   
* Usuário acessa página de geração de pedido.
* Model de pedido criado (order).
* Show e index configurados, com mudanças na exposição de preços.
## Telas: 
1. Página de geração de pedido:
![image](https://user-images.githubusercontent.com/103471865/173933253-27563bad-b710-4535-b926-d4a3987f8474.png)
2. Página de show:
![image](https://user-images.githubusercontent.com/103471865/174335545-c511ff9a-d2dc-45e8-957e-20d415080416.png)
3. Index de pedidos: 
![image](https://user-images.githubusercontent.com/103471865/174335464-d7548405-cc74-4547-8c12-af160e0157f1.png)


