### PR TITLE
Resolve problema na data do preço

### DIFF
--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -1,8 +1,9 @@
 class CartItemsController < ApplicationController
   before_action :get_user_id, except: :destroy
+  before_action :authenticate_user!, except: :create
   
   def index
-    @cart = CartItem.where(user_id: @user_id)
+    @cart = CartItem.where(user_id: @user_id, order_id: nil)
   end
 
   def create 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,52 @@
+class OrdersController < ApplicationController
+  before_action :get_user, only: [:index, :new, :create]
+  before_action :get_cart_and_sum, only: [:new, :create]
+  before_action :authenticate_user!
+
+  def index
+    @orders = Order.where(user_id: @user_id) 
+  end
+  
+  def new
+    @order = Order.new
+  end
+
+  def show
+    @order = Order.find(params[:id])
+    @cart = @order.cart_items
+    @sum = 0
+    @cart.each do |ci| 
+      @sum += ci.price_on_purchase * ci.quantity
+    end
+  end
+  
+  def create
+    @order_params = params.require(:order).permit(:address, :user_id)
+    @order = Order.new(@order_params)
+    if @order.save
+      flash[:notice] = "Pedido efetuado com sucesso"
+      redirect_to @order
+    else
+      flash[:alert] = "Falha ao efetuar o pedido"
+      render 'new'
+    end
+  end
+
+  private
+
+  def get_user
+    @user_id = params[:user_id]
+  end
+
+  def get_cart_and_sum
+    @cart = CartItem.where(user_id: @user_id, order_id: nil)
+    @sum = 0
+    @cart.each do |ci| 
+      @sum += ci.product.prices
+                .where('validity_start <= ?', DateTime.current)
+                .order(validity_start: :asc)
+                .last
+                .price_in_brl * ci.quantity
+    end
+  end
+end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,15 +1,9 @@
 class ProductsController < ApplicationController
   def show
     @product = Product.find_by(id: params[:id])
-    
     return redirect_to root_path, alert: 'Produto não encontrado' if @product.nil?
     return redirect_to root_path, alert: 'Produto não encontrado' unless admin_signed_in? || @product.on_shelf?
-
-    @current_price = @product.prices
-                             .where('validity_start <= ?', DateTime.current)
-                             .order(validity_start: :asc)
-                             .last
-                             .price_in_brl
+    @current_price = @product.current_price
   end
   
   def update_status
@@ -21,6 +15,5 @@ class ProductsController < ApplicationController
       error_details = product.errors.full_messages.join(', ').downcase
       redirect_to product, alert: "Houve um erro. Para colocar um produto à venda, #{error_details}."
     end
-    
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
   def show
     @product = Product.find_by(id: params[:id])
+    
     return redirect_to root_path, alert: 'Produto não encontrado' if @product.nil?
     return redirect_to root_path, alert: 'Produto não encontrado' unless admin_signed_in? || @product.on_shelf?
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,9 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  self.abstract_class = true
+
+  def self.human_enum_name(enum_name, enum_value)
+    I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}")
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,32 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  has_many :cart_items
+  validates_presence_of :address
+  validate :must_have_cart
+
+  before_create :set_code
+  after_create :process_cart
+
+  enum status: {pending: 0, approved: 5, canceled: 9}
+  
+  private
+
+  def set_code
+    self.code = SecureRandom.alphanumeric(8).upcase.insert(4, '-')
+  end
+
+  def process_cart
+    CartItem.where(order_id: nil, user: self.user).each do |ci|
+      ci.update(order_id: self.id)
+      ci.update(price_on_purchase: ci.product.prices
+                                     .where('validity_start <= ?', DateTime.current)
+                                     .order(validity_start: :asc)
+                                     .last
+                                     .price_in_brl)
+    end
+  end
+
+  def must_have_cart
+    return errors.add(:pedido, 'deve possuir carrinho.') if CartItem.where(order_id: nil, user: self.user).empty?
+  end
+end

--- a/app/models/price.rb
+++ b/app/models/price.rb
@@ -9,7 +9,7 @@ class Price < ApplicationRecord
   private
 
   def validity_start_is_future
-    if validity_start.present? && validity_start < DateTime.now
+    if validity_start.present? && validity_start < 2.seconds.ago
       errors.add(:validity_start, 'não pode estar no passado')
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,4 +7,22 @@ class Product < ApplicationRecord
   has_many :prices
 
   enum status: { off_shelf: 0, draft: 5, on_shelf: 9 }
+  
+  def set_price(price_in_brl, validity_start = 1.second.ago)
+    Price.create!(price_in_brl: price_in_brl,
+                  validity_start: validity_start,
+                  product_id: self.id)
+    return self
+  end
+
+  def current_price
+    return nil if self.prices.empty?
+    return nil if self.prices.where('validity_start <= ?', DateTime.current).empty?
+    
+    self.prices
+        .where('validity_start <= ?', DateTime.current)
+        .order(validity_start: :asc)
+        .last
+        .price_in_brl
+  end
 end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,5 +1,5 @@
 class ApplicationService
-  def self.get_branches(*args, &blocks)
-    new(*args, &blocks).get_branches
+  def self.process_cart(*args, &blocks)
+    new(*args, &blocks).process_cart
   end
 end

--- a/app/views/cart_items/index.html.erb
+++ b/app/views/cart_items/index.html.erb
@@ -1,19 +1,33 @@
 <h3 class='text-center'>Meu Carrinho</h3>
 
-<table class="table text-center align-middle m-auto" style="max-width: 900px">
-  <thead>
-    <tr>
-      <th>Produto</th>
-      <th>Quantidade</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @cart.each do |ci|%>
+<% if @cart.empty?%>
+  <strong>Adicione um produto ao carrinho!</strong>
+<% else %>
+  <table class="table text-center align-middle m-auto" style="max-width: 900px">
+    <thead>
       <tr>
-        <td class="text-start"> <%= link_to ci.product.name, product_path(ci.product.id) %></td>
-        <td class="text-center"> <strong> <%=ci.quantity%> </strong></td>
-        <td><%= button_to 'Retirar', cart_item_path(ci.id), class: 'btn btn-outline-warning mini-button', method: :delete %> </td>
+        <th>Produto</th>
+        <th>Quantidade</th>
+        <th>Preço</th>
       </tr>
-    <%end%>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @cart.each do |ci|%>
+        <tr>
+          <td class="text-start"> <%= link_to ci.product.name, product_path(ci.product.id) %></td>
+          <td class="text-center"> <strong> <%=ci.quantity%>  </strong></td> 
+          <td class="text-center"> <strong> <%=number_to_currency(ci.product.prices
+                                                .where('validity_start <= ?', DateTime.current)
+                                                .order(validity_start: :asc)
+                                                .last
+                                                .price_in_brl, precision: 2)%> </strong></td>
+          <td><%= button_to 'Retirar', cart_item_path(ci.id), class: 'btn btn-outline-warning mini-button', method: :delete %> </td>
+        </tr>
+      <%end%>
+    </tbody>
+  </table>
+
+  <div class="text-center buffer">
+    <%= link_to 'Finalizar Pedido', new_user_order_path(@cart.last.user_id), class: 'btn btn-outline-primary mini-button' %>
+  </div>
+<% end %>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -42,6 +42,10 @@
         <li class="nav-link">
           <%= link_to 'Meu Carrinho', user_cart_items_path(current_user.id), class: 'text-light text-decoration-none' %>
         </li>
+        
+        <li class="nav-link">
+          <%= link_to 'Meus Pedidos', user_orders_path(current_user.id), class: 'text-light text-decoration-none' %>
+        </li>
 
         <li class="nav-link">
           <%= button_to 'Sair', destroy_user_session_path, method: :delete, class: 'btn btn-light mini-button' %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,11 @@
+<% if @orders.empty? %>
+  <p class='text center'>
+    <strong> Você ainda não possui nenhum pedido. </strong>
+  </p>
+<% else %>
+  <% @orders.each do |o|%>
+    <div>
+      Pedido <%= link_to o.code, order_path(o.id) %> - <%= Order.human_enum_name(:status, o.status)%>
+    </div>
+  <%end%>
+<% end %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,0 +1,44 @@
+<h3 class='text-center'>Meu Pedido</h3>
+
+<table class="table text-center align-middle m-auto" style="max-width: 900px">
+  <thead>
+    <tr>
+      <th>Produto</th>
+      <th>Quantidade</th>
+      <th>Preço</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @cart.each do |ci|%>
+      <tr>
+        <td class="text-start"> <%= link_to ci.product.name, product_path(ci.product.id) %></td>
+        <td class="text-center"> <strong> <%=ci.quantity%>  </strong></td> 
+        <td class="text-center"> <strong> <%=number_to_currency(ci.product.prices
+                                               .where('validity_start <= ?', DateTime.current)
+                                               .order(validity_start: :asc)
+                                               .last
+                                               .price_in_brl, precision: 2)%> </strong></td>
+        <td><%= button_to 'Retirar', cart_item_path(ci.id), class: 'btn btn-outline-warning mini-button', method: :delete %> </td>
+      </tr>
+    <%end%>
+    <tr>
+      <td></td>
+      <td class="text-center"> <strong>Valor Total:</strong></td>
+      <td class="text-center"> <strong><%=number_to_currency(@sum)%></strong></td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="text center standard-width m-auto">
+  <%= simple_form_for @order, url: user_orders_path(@user_id) do |cat| %>
+    <%= cat.input :address %>
+    <%= cat.input :user_id, :as => :hidden, :input_html => {value: @user_id} %>
+    <div class="text-center little-buffer">
+      <%= cat.button :submit, 'Confirmar', class: 'btn btn-warning' %>
+    </div>
+  <% end %>
+
+  <div class="text-center buffer">
+    <%= link_to 'Voltar', user_cart_items_path(@user_id), class: 'btn btn-outline-primary mini-button' %>
+  </div>
+</div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,0 +1,32 @@
+<h3 class='text-center'>Pedido <%=@order.code%></h3>
+<table class="table text-center align-middle m-auto" style="max-width: 900px">
+  <thead>
+    <tr>
+      <th>Produto</th>
+      <th>Quantidade</th>
+      <th>Preço</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @cart.each do |ci|%>
+      <tr>
+        <td class="text-start"> <%= link_to ci.product.name, product_path(ci.product.id) %></td>
+        <td class="text-center"> <strong> <%=ci.quantity%>  </strong></td> 
+        <td class="text-center"> <strong> <%=number_to_currency(ci.price_on_purchase, precision: 2)%> </strong></td>
+      </tr>
+    <%end%>
+    <tr>
+      <td></td>
+      <td class="text-center"> <strong>Valor Total:</strong></td>
+      <td class="text-center"> <strong><%=number_to_currency(@sum)%></strong></td>
+    </tr>
+    <tr>
+      <td colspan="2" class="text-center"> <strong>Endereço de entrega:</strong></td>
+      <td class="text-center"> <strong><%=@order.address%></strong></td>
+    </tr>
+    <tr>
+      <td colspan="2" class="text-center"> <strong><%=Order.human_attribute_name(:status)%>:</strong></td>
+      <td class="text-center"> <strong><%=Order.human_enum_name(:status, @order.status)%></strong></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -29,7 +29,7 @@
   <%user_id = user_signed_in? ? current_user.id : user_id = 0%>  
   <%= form_with url: user_cart_items_path(user_id) do |f|%>
     <%= f.label :quantity, 'Quantidade'%>
-    <%= f.number_field :quantity%>
+    <%= f.number_field :quantity, min: 1, value: 1%>
     <%= f.hidden_field :product_id, value: @product.id%>
     <%= f.submit 'Adicionar ao carrinho'%>
   <%end%>

--- a/config/locales/models/cart_item_pt-BR.yml
+++ b/config/locales/models/cart_item_pt-BR.yml
@@ -1,0 +1,9 @@
+pt-BR:
+  activerecord:
+    models:
+      cart_item:
+        one: Item
+        other: Carrinho
+    attributes:
+      cart_item:
+        quantity: Quantidade

--- a/config/locales/models/order_pt-BR.yml
+++ b/config/locales/models/order_pt-BR.yml
@@ -1,0 +1,13 @@
+pt-BR:
+  activerecord:
+    models:
+      order:
+        one: Pedido
+        other: Pedidos
+    attributes:
+      order:
+        address: Endereço de entrega
+        statuses:
+          pending: Pendente
+          approved: Aprovado
+          canceled: Cancelado

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   resources :product_categories, only: [:index, :show, :new, :create, :edit, :update]
 
   resources :users, shallow: true do
-    resources :cart_items, only: [:create, :index, :destroy]
+    resources :cart_items, only: [:index, :create, :destroy]
+    resources :orders, only: [:index, :show, :new, :create]
   end
 end

--- a/db/migrate/20220615205221_create_orders.rb
+++ b/db/migrate/20220615205221_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220615205713_add_order_to_cart_items.rb
+++ b/db/migrate/20220615205713_add_order_to_cart_items.rb
@@ -1,0 +1,5 @@
+class AddOrderToCartItems < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :cart_items, :order, foreign_key: true
+  end
+end

--- a/db/migrate/20220615224648_add_code_to_order.rb
+++ b/db/migrate/20220615224648_add_code_to_order.rb
@@ -1,0 +1,5 @@
+class AddCodeToOrder < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :code, :string
+  end
+end

--- a/db/migrate/20220616234014_add_status_to_order.rb
+++ b/db/migrate/20220616234014_add_status_to_order.rb
@@ -1,0 +1,5 @@
+class AddStatusToOrder < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :status, :integer
+  end
+end

--- a/db/migrate/20220617003446_add_price_on_purchase_to_cart_items.rb
+++ b/db/migrate/20220617003446_add_price_on_purchase_to_cart_items.rb
@@ -1,0 +1,5 @@
+class AddPriceOnPurchaseToCartItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cart_items, :price_on_purchase, :decimal
+  end
+end

--- a/db/migrate/20220617121724_add_default_value_to_orders_status.rb
+++ b/db/migrate/20220617121724_add_default_value_to_orders_status.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueToOrdersStatus < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :orders, :status, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_16_133645) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_17_121724) do
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -30,8 +30,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_16_133645) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "order_id"
+    t.decimal "price_on_purchase"
+    t.index ["order_id"], name: "index_cart_items_on_order_id"
     t.index ["product_id"], name: "index_cart_items_on_product_id"
     t.index ["user_id"], name: "index_cart_items_on_user_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "code"
+    t.integer "status", default: 0
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "prices", force: :cascade do |t|
@@ -58,9 +71,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_16_133645) do
     t.string "sku"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "product_category_id"
     t.integer "status", default: 5
-    t.index ["product_category_id"], name: "index_products_on_product_category_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -76,8 +87,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_16_133645) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "cart_items", "orders"
   add_foreign_key "cart_items", "products"
   add_foreign_key "cart_items", "users"
+  add_foreign_key "orders", "users"
   add_foreign_key "prices", "products"
-  add_foreign_key "products", "product_categories"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,13 +54,17 @@ moveis = ProductCategory.create(name: "Móveis")
 mesa_escritorio = ProductCategory.create(name: "Mesa de Escritório", parent: moveis)
 guarda_roupa = ProductCategory.create(name: "Guarda-roupa", parent: moveis)
 
-# Create Carts
-CartItem.create!(product: Product.first, quantity: 5, user: user )
-CartItem.create!(product: Product.last, quantity: 7, user: user )
+# Create Carts and Orders
+CartItem.create!(product: product1, quantity: 5, user: user )
+CartItem.create!(product: product2, quantity: 7, user: user )
+Order.create!(address: 'Rua da entrega, 75', user: user)
+CartItem.create!(product: product3, quantity: 5, user: user )
+CartItem.create!(product: product1, quantity: 7, user: user )
 
 p "Foram criados #{Admin.count} admins"
 p "Foram criados #{User.count} usuários"
 p "Foram criados #{Product.count} produtos"
 p "Foram criados um total de #{Price.count} preços para #{Price.select(:product_id).distinct.count} produtos"
 p "Foram criadas #{ProductCategory.count} categorias de produtos"
-p "Foram criadas #{CartItem.count} instâncias de carrinho"
+p "Foram criadas #{CartItem.count} instâncias de item de carrinho"
+p "Foram criadas #{Order.count} instâncias de pedidos"

--- a/spec/factories/cart_items.rb
+++ b/spec/factories/cart_items.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :cart_item do
     product
     user
+    order_id { nil }
     quantity { 1 }
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :order do
+    user 
+    address { "Rua da Entrega, 54" }
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  describe '#valid?' do
+    it {should belong_to(:user)}
+    it {should have_many(:cart_items)}
+    it {should validate_presence_of(:address)}
+
+    context 'when cart' do
+      it "doesn't exist gives false" do
+        order = build(:order)
+
+        expect(order.valid?).to be_falsey
+        expect(order.errors.full_messages).to include 'Pedido deve possuir carrinho.' 
+      end
+
+      it "exists gives true" do
+        user = create(:user)
+        product = create(:product)
+        create(:price, product: product)
+        create(:cart_item, user: user, product: product)
+        order = build(:order, user: user)
+
+        expect(order).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/models/price_spec.rb
+++ b/spec/models/price_spec.rb
@@ -8,20 +8,28 @@ RSpec.describe Price, type: :model do
     it { should validate_presence_of :validity_start}
     it { should validate_numericality_of(:price_in_brl).is_greater_than(0) }
 
-    it 'is expected to validate that :validity_start is unique within the scope of a Product'  do
-      FactoryBot.create(:price)
-      should validate_uniqueness_of(:validity_start)
-        .scoped_to(:product_id)
-        .with_message('já está cadastrada em outra instância de Price para este produto')
-    end
+    context 'is expected to validate that :validity_start'  do
+      it 'is unique within the scope of a Product'  do
+        create(:price)
+        should validate_uniqueness_of(:validity_start)
+          .scoped_to(:product_id)
+          .with_message('já está cadastrada em outra instância de Price para este produto')
+      end
 
-    it 'is expected to validate that :validity_start cannot be set in the past' do
-      price = Price.new(validity_start: 1.day.ago, price_in_brl: 5)
+      it 'cannot be set in the distant past' do
+        price = build(:price, validity_start: 1.day.ago, price_in_brl: 5)
 
-      price.valid?
+        price.valid?
 
-      expect(price.errors.include?(:validity_start)).to be true
-      expect(price.errors[:validity_start]).to include('não pode estar no passado')
+        expect(price.errors.include?(:validity_start)).to be true
+        expect(price.errors[:validity_start]).to include('não pode estar no passado')
+      end
+
+      it 'can be set in the immediate past' do
+        price = build(:price, validity_start: 1.second.ago, price_in_brl: 5, product: build(:product))
+
+        expect(price).to be_valid
+      end
     end
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -73,4 +73,66 @@ RSpec.describe Product, type: :model do
       end
     end
   end
+
+  describe '#set_price' do
+    it 'should create a Price with validity start as now if no datetime is passed' do
+      product = create(:product).set_price(15)
+      another_product = create(:product).set_price(8.51)
+
+      price = Price.first
+      another_price = Price.last
+
+      expect(price.price_in_brl).to eq 15
+      expect(price.product_id).to be product.id
+      expect(product.prices).to include(price)
+      expect(product.prices).not_to include(another_price)
+      expect(another_price.price_in_brl).to eq 8.51
+      expect(another_price.product_id).to be another_product.id
+      expect(another_product.prices).to include(another_price)
+      expect(another_product.prices).not_to include(price)
+    end
+
+    it 'should create a Price with validity start in the future if a datetime is passed' do
+      product = create(:product).set_price(51.01, 2.months.from_now)
+
+      price = Price.first
+      creation_lag =  2.months.from_now - price.validity_start
+      diff_between_time_asked_and_time_persisted = creation_lag < 0 ? creation_lag * (-1) : creation_lag
+      # while the creation_lag is always positive, calculating its absolute value helps 
+      # expose bugs (ie: asked to create validity_start 2 months from now, created 3 months 
+      # from now, diff = - 1 months (negative), which is less than 2 seconds and would pass the test)
+
+      expect(price.price_in_brl).to eq 51.01
+      expect(price.product_id).to be product.id
+      expect(product.prices).to include(price)
+      expect(diff_between_time_asked_and_time_persisted).to be < 2.seconds
+    end
+  end
+
+  describe '#current_price' do
+    it 'should choose the correct current Price of a Product' do
+      Timecop.freeze(1.year.ago) do
+        product = create(:product).set_price(5.99)
+        product.set_price(10.51, 11.months.from_now)
+      end
+      product = Product.first.set_price(14.99, 2.months.from_now)
+
+      expect(product.current_price).to eq 10.51
+    end
+
+    it 'should return nil if the product has no prices at all' do
+      product = create(:product)
+
+      expect(product.prices).to be_empty
+      expect(product.current_price).to be nil
+    end
+
+    it 'should return nil if the product only has prices with validity start in the future' do
+      product = create(:product)
+      price = create(:price, price_in_brl: 22.22, validity_start: 2.months.from_now, product: product)
+
+      expect(product.prices).to include(price)
+      expect(product.current_price).to be nil
+    end
+  end
 end

--- a/spec/system/order/user_cart_view_spec.rb
+++ b/spec/system/order/user_cart_view_spec.rb
@@ -4,16 +4,10 @@ describe 'User enters cart page' do
   it 'and sees cart items' do
     user = create(:user)
     user_2 = create(:user, name: 'Jaime', email: 'jaime@meuemail.com')
-    product_1 = create(:product, name: 'Caneca', status: 'on_shelf')
-    product_2 = create(:product, name: 'Garrafa', status: 'on_shelf')
-    product_3 = create(:product, name: 'Jarra', status: 'on_shelf')
-    product_4 = create(:product, name: 'Pote')
-    Timecop.freeze(1.month.ago) do
-      create(:price, product: product_1, price_in_brl: '11.99')
-      create(:price, product: product_2, price_in_brl: '4.99')
-      create(:price, product: product_3, price_in_brl: '15.99')
-      create(:price, product: product_4, price_in_brl: '2.99')
-    end
+    product_1 = create(:product, name: 'Caneca', status: 'on_shelf').set_price(11.99)
+    product_2 = create(:product, name: 'Garrafa', status: 'on_shelf').set_price(4.99)
+    product_3 = create(:product, name: 'Jarra', status: 'on_shelf').set_price(15.99)
+    product_4 = create(:product, name: 'Pote', status: 'draft').set_price(2.99)
     create(:cart_item, product: product_1, quantity: 3, user: user)
     create(:cart_item, product: product_2, quantity: 7, user: user)
     create(:cart_item, product: product_3, quantity: 5, user: user_2)
@@ -32,12 +26,8 @@ describe 'User enters cart page' do
   it 'and there are no cart items' do
     user = create(:user)
     user_2 = create(:user, name: 'Jaime', email: 'jaime@meuemail.com')
-    product_1 = create(:product, name: 'Jarra', sku: 'JRA68755')
-    product_2 = create(:product, name: 'Pote', sku: 'PTE68755')
-    Timecop.freeze(1.month.ago) do
-      create(:price, product: product_1, price_in_brl: "15.99")
-      create(:price, product: product_2, price_in_brl: "2.99")
-    end
+    product_1 = create(:product, name: 'Jarra').set_price(15.99)
+    product_2 = create(:product, name: 'Pote').set_price(2.99)
     create(:cart_item, product: product_1, quantity: 7, user: user_2)
     create(:cart_item, product: product_2, quantity: 5, user: user_2)
 
@@ -52,14 +42,9 @@ describe 'User enters cart page' do
   
   it 'after adding a product' do
     user = create(:user)
-    product_1 = create(:product, name: 'Caneca', status: 'on_shelf')
-    product_2 = create(:product, name: 'Garrafa', status: 'on_shelf')
-    product_3 = create(:product, name: 'Jarra', status: 'on_shelf')
-    Timecop.freeze(1.month.ago) do
-      create(:price, product: product_1, price_in_brl: "11.99")
-      create(:price, product: product_2, price_in_brl: "4.99")
-      create(:price, product: product_3, price_in_brl: "15.99")
-    end
+    product_1 = create(:product, name: 'Caneca', status: 'on_shelf').set_price(11.99)
+    product_2 = create(:product, name: 'Garrafa', status: 'on_shelf').set_price(4.99)
+    product_3 = create(:product, name: 'Jarra', status: 'on_shelf').set_price(15.99)
     create(:cart_item, product: product_1, quantity: 3, user:  user)
     create(:cart_item, product: product_2, quantity: 7, user:  user)
 
@@ -70,21 +55,17 @@ describe 'User enters cart page' do
     click_on "Adicionar ao carrinho"
     click_on "Meu Carrinho"
     
+    expect(current_path).to eq user_cart_items_path(user)
     expect(page).to have_content "Caneca"
     expect(page).to have_content "Garrafa"
     expect(page).to have_content "Jarra"
   end
 
-  it 'and withdraws an item ' do
+  it 'and withdraws an item' do
     user = create(:user)
-    product_1 = create(:product, name: 'Caneca', status: 'on_shelf')
-    product_2 = create(:product, name: 'Garrafa', status: 'on_shelf')
-    product_3 = create(:product, name: 'Jarra', status: 'on_shelf')
-    Timecop.freeze(1.month.ago) do
-      create(:price, product: product_1, price_in_brl: "11.99")
-      create(:price, product: product_2, price_in_brl: "4.99")
-      create(:price, product: product_3, price_in_brl: "15.99")
-    end
+    product_1 = create(:product, name: 'Caneca', status: 'on_shelf').set_price(11.99)
+    product_2 = create(:product, name: 'Garrafa', status: 'on_shelf').set_price(4.99)
+    product_3 = create(:product, name: 'Jarra', status: 'on_shelf').set_price(15.99)
     create(:cart_item, product: product_1, quantity: 3, user: user)
     create(:cart_item, product: product_2, quantity: 7, user: user)
     create(:cart_item, product: product_3, quantity: 5, user: user)
@@ -106,10 +87,7 @@ describe 'User enters cart page' do
 
   it 'and enters product page through cart link' do
     user = create(:user)
-    product = create(:product, name: 'Caneca', status: 'on_shelf')
-    Timecop.freeze(1.month.ago) do
-      create(:price, product: product)
-    end
+    product = create(:product, name: 'Caneca', status: 'on_shelf').set_price(8.44)
     create(:cart_item, product: product, quantity: 3, user: user)
 
     login_as(user, scope: :user)
@@ -120,5 +98,6 @@ describe 'User enters cart page' do
     end
     
     expect(current_path).to eq product_path(product)
+    expect(page).to have_text 'Caneca'
   end
 end

--- a/spec/system/order/user_confirms_order_spec.rb
+++ b/spec/system/order/user_confirms_order_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+describe "User confirms order from cart" do
+  it "and sees order generate page" do
+    user = create(:user)
+    product_1 = create(:product, name: 'Caneca')
+    product_2 = create(:product, name: 'Garrafa', sku: 'GRF9933')
+    product_3 = create(:product, name: 'Jarra', sku: 'JRA68755')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1, price_in_brl: "11.99")
+      create(:price, product: product_2, price_in_brl: "4.99")
+      create(:price, product: product_3, price_in_brl: "15.99")
+    end
+    create(:cart_item, product: product_1, quantity: 3, user: user)
+    create(:cart_item, product: product_2, quantity: 7, user: user)
+    create(:cart_item, product: product_3, quantity: 5, user: user)
+
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meu Carrinho"
+    click_on "Finalizar Pedido"
+    
+    expect(page).to have_content "Meu Pedido"
+    expect(page).to have_content "Produto Quantidade Preço"
+    expect(page).to have_content "Caneca 3 R$ 11,99"
+    expect(page).to have_content "Garrafa 7 R$ 4,99"
+    expect(page).to have_content "Jarra 5 R$ 15,99"
+    expect(page).to have_content "Valor Total: R$ 150,85"
+    expect(page).to have_field "Endereço de entrega" 
+    expect(page).to have_button "Confirmar" 
+    expect(page).to have_link "Voltar"
+  end
+
+  it "and generates order" do
+    user = create(:user)
+    product_1 = create(:product, name: 'Caneca')
+    product_2 = create(:product, name: 'Garrafa', sku: 'GRF9933')
+    product_3 = create(:product, name: 'Jarra', sku: 'JRA68755')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1, price_in_brl: "11.99")
+      create(:price, product: product_2, price_in_brl: "4.99")
+      create(:price, product: product_3, price_in_brl: "15.99")
+    end
+    create(:cart_item, product: product_1, quantity: 3, user: user)
+    create(:cart_item, product: product_2, quantity: 7, user: user)
+    create(:cart_item, product: product_3, quantity: 5, user: user)
+    allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('123ASD45')
+
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meu Carrinho"
+    click_on "Finalizar Pedido"
+    fill_in "Endereço de entrega", with: "Rua da entrega, 45"
+    click_on "Confirmar"
+
+    expect(page).to have_content 'Pedido 123A-SD45'
+    expect(page).to have_content "Produto Quantidade Preço"
+    expect(page).to have_content "Caneca 3 R$ 11,99"
+    expect(page).to have_content "Garrafa 7 R$ 4,99"
+    expect(page).to have_content "Jarra 5 R$ 15,99"
+    expect(page).not_to have_button "Retirar"
+    expect(page).to have_content "Valor Total: R$ 150,85"
+    expect(page).to have_content "Endereço de entrega: Rua da entrega, 45" 
+    expect(page).to have_content "Status: Pendente"
+    expect(page).to have_link "Voltar"
+  end
+
+  it "and fails to generate order" do
+    user = create(:user)
+    product_1 = create(:product, name: 'Caneca')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1)
+    end
+    create(:cart_item, product: product_1, quantity: 3, user: user)
+    allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('123ASD45')
+
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meu Carrinho"
+    click_on "Finalizar Pedido"
+    fill_in "Endereço de entrega", with: ""
+    click_on "Confirmar"
+
+    expect(page).to have_content "Endereço de entrega não pode estar em branco"
+  end
+end

--- a/spec/system/order/user_view_order_details_spec.rb
+++ b/spec/system/order/user_view_order_details_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'User enters order detail page' do
+  it "and sees prices set on date of purchase" do
+    user = create(:user)
+    product = create(:product, name: 'Caneca')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product, price_in_brl: "11.99")
+      create(:price, product: product, price_in_brl: "4.99", validity_start: 15.days.from_now)
+    end
+    Timecop.freeze(20.days.ago) do
+      create(:cart_item, product: product, quantity: 3, user: user)
+      @order_1 = create(:order, user: user, status: 'pending')
+    end
+    
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meus Pedidos"
+    click_on "#{@order_1.code}"
+
+    expect(page).to have_content "R$ 11,99"
+    expect(page).to have_content "Valor Total: R$ 35,97"
+  end
+end

--- a/spec/system/order/user_view_orders_spec.rb
+++ b/spec/system/order/user_view_orders_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe "User enters orders page" do
+  it "and views own orders" do
+    user = create(:user)
+    user_2 = create(:user, name: 'Maciel', email: 'maciel@meuemail.com')
+    product_1 = create(:product, name: 'Caneca')
+    product_2 = create(:product, name: 'Garrafa', sku: 'GRF9933')
+    product_3 = create(:product, name: 'Jarra', sku: 'JRA68755')
+    Timecop.freeze(1.month.ago) do
+      create(:price, product: product_1, price_in_brl: "11.99")
+      create(:price, product: product_2, price_in_brl: "4.99")
+      create(:price, product: product_3, price_in_brl: "15.99")
+    end
+    create(:cart_item, product: product_1, quantity: 3, user: user)
+    create(:cart_item, product: product_2, quantity: 7, user: user)
+    create(:cart_item, product: product_3, quantity: 5, user: user_2)
+    order_1 = create(:order, user: user, status: 'pending')
+    order_3 = create(:order, user: user_2, status: 'pending')
+
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meus Pedidos"
+
+    expect(page).to have_content "Pedido #{order_1.code} - Pendente"
+    expect(page).not_to have_content "Pedido #{order_3.code} - Pendente"
+  end
+
+  it "and there are no orders" do
+    user = create(:user)
+    
+    login_as(user, scope: :user)
+    visit root_path
+    click_on "Meus Pedidos"
+
+    expect(page).to have_content "Você ainda não possui nenhum pedido."
+  end
+end

--- a/spec/system/product/visitor_put_product_on_cart_spec.rb
+++ b/spec/system/product/visitor_put_product_on_cart_spec.rb
@@ -2,10 +2,7 @@ require 'rails_helper'
 
 describe "User adds product to cart" do
   it "successfully" do
-    product = create(:product, name: 'Caneca Mon Amour', status: 'on_shelf')
-    Timecop.freeze(1.month.ago) do
-      create(:price, product: product)
-    end
+    product = create(:product, name: 'Caneca Mon Amour', status: 'on_shelf').set_price(4.44)
     user = create(:user)
     
     login_as(user, scope: :user)
@@ -18,10 +15,7 @@ describe "User adds product to cart" do
   end
   
   it "and is redirected to login page when logged out" do
-    product = create(:product, name: 'Caneca Mon Amour', status: 'on_shelf')
-    Timecop.freeze(1.month.ago) do
-      create(:price, product: product)
-    end
+    product = create(:product, name: 'Caneca Mon Amour', status: 'on_shelf').set_price(4.44)
   
     visit root_path
     click_on 'Caneca Mon Amour'
@@ -33,10 +27,7 @@ describe "User adds product to cart" do
   
   it 'and is rejected for invalid quantity' do
     user = create(:user)
-    product = create(:product, name: 'Caneca', status: 'on_shelf')
-    Timecop.freeze(1.month.ago) do
-      create(:price, product: product)
-    end
+    product = create(:product, name: 'Caneca', status: 'on_shelf').set_price(4.44)
   
     login_as(user, scope: :user)
     visit root_path


### PR DESCRIPTION
A validação requer o preço ter data de início de validade no futuro. Mas para exibir um produto, ele deve ter algum preço com data de validade com início no passado.

Isso criava uma complicação para os testes, pois de acordo com a velocidade de processamento, às vezes a validação falhava pois o Time.current que tinha sido calculado ao construir a instância já era passado ao salvar a instância, falhando nos testes.

Se a gente tentasse resolver isso criando um preço um pouco no futuro (tipo 1s), às vezes no momento de processar a view, esse preço ainda era passado e quebrava a view.
Então para resolver, se trocou a validação para permitir que os preços sejam criados ligeiramente no passado, tipo 2s.

Também foi criado um método Product#current_price para ajudar a selecionar o preço atual. E um método Product#set_price para facilitar o instanciamento de um preço relacionado ao produto.
Este PR envolve principalmente testes unitários, então não tem view pertinente para mostrar.
