### PR TITLE
Implementa busca de produtos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ Mercadores é uma loja virtual que permite a compra de produtos mediante pagamen
 
 ## Domínio
 
-Um **produto** (`Product`) é o que se vende. Ele pode ter status *em rascunho* (`draft`), *à venda*(`on_shelf`) e *suspenso* (`off_shelf`). Apenas produtos à venda aparecem para os usuários finais.  
+Um **produto** (`Product`) é o que se vende. Ele pode ter status *em rascunho* (`draft`), *à venda* (`on_shelf`) ou *suspenso* (`off_shelf`). Apenas produtos à venda aparecem para os usuários finais.  
   
 Desses produtos que aparecem, um usuário pode colocá-los num carrinho e gerar um **pedido** (`Order`), que é posteriormente processado pelo [serviço de pagamentos](https://github.com/TreinaDev/pagamentos-td08-time01).  
   
-Os **preço**s (`Price`) de um produto podem ser atualizados automaticamente de acordo com uma data previamente indicada por algum admin do sistema.
-
+Os **preços** (`Price`) de um produto podem ser atualizados automaticamente de acordo com uma data previamente indicada por algum admin do sistema.  
+  
+Os produtos são organizados em **categorias** (`ProductCategory`), que tem uma organização do tipo árvore.  
+  
+Esta aplicação prevê 3 tipos de usuários: **administradores** (`Admin`), que são empregados do e-commerce gerenciando a oferta de produtos, seus preços e também os pedidos; **consumidores** (`User`), os clientes da plataforma quando estão logados; e **visitantes**, qualquer usuário não logado.  
 
 ## Versão do Ruby
 ![This app requires Ruby 3.1.0 to be installed](https://img.shields.io/static/v1?label=ruby&message=version%203.1.0&color=B61D1D&style=for-the-badge&logo=ruby)  
@@ -64,7 +67,7 @@ Esta é a equipe 1, composta por 9 pessoas divididas na frente de **e-commerce**
 - [Davide Almeida](https://github.com/davide-almeida)
 - [Jhonny Toledo](https://github.com/Jhonny4975)
 - [Júnior Beto](https://github.com/b-sep)
-- [kyrir](https://github.com/kyriri)
+- [kyriri](https://github.com/kyriri)
 - [Lucas Borges](https://github.com/LucasDLAB)
 - [Maciel Júnior](https://github.com/macieljuniormax)
 - [Philipe Leandro](https://github.com/philipeleandro)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mercadores - Um site de regate de pontos
+# Mercadores - Um site de resgate de pontos
 
 :warning:  projeto em desenvolvimento  
   

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ApplicationController
   def index
     @products = Product.on_shelf
+    @message_if_empty = 'Não existem produtos cadastrados'
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -5,6 +5,15 @@ class ProductsController < ApplicationController
     return redirect_to root_path, alert: 'Produto não encontrado' unless admin_signed_in? || @product.on_shelf?
     @current_price = @product.current_price
   end
+
+  def search
+    sanitized_and_split_query_array = Product.sanitize_sql_like(params[:query]).split.map { |keyword| '%' + keyword + '%' }
+    @products = sanitized_and_split_query_array.reduce([]) { |memo, query|
+      memo << Product.where('name LIKE ?', query)
+    }.flatten
+    @products = @products.filter(&:on_shelf?) unless admin_signed_in? || @products.empty?
+    render 'home/index'
+  end
   
   def update_status
     return unless admin_signed_in?

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -9,6 +9,7 @@ class ProductsController < ApplicationController
   def search
     @products = Search.new(params[:query]).inside_products
     @products = @products.filter(&:on_shelf?) unless admin_signed_in? || @products.empty?
+    @message_if_empty = "Nenhum resultado encontrado para: #{params[:query]}"
     render 'home/index'
   end
   

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -7,13 +7,7 @@ class ProductsController < ApplicationController
   end
 
   def search
-    sanitized_and_split_query_array = Product.sanitize_sql_like(params[:query]).split.map { |keyword| '%' + keyword + '%' }
-    @products = sanitized_and_split_query_array.reduce([]) { |memo, query|
-      memo << Product.where('name LIKE ?', query)
-      memo << Product.where('description LIKE ?', query)
-      memo << Product.where('brand LIKE ?', query)
-      memo << Product.where('sku LIKE ?', query)
-    }.flatten
+    @products = Search.products(params[:query])
     @products = @products.filter(&:on_shelf?) unless admin_signed_in? || @products.empty?
     render 'home/index'
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -7,7 +7,7 @@ class ProductsController < ApplicationController
   end
 
   def search
-    @products = Search.products(params[:query])
+    @products = Search.new(params[:query]).inside_products
     @products = @products.filter(&:on_shelf?) unless admin_signed_in? || @products.empty?
     render 'home/index'
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -10,6 +10,9 @@ class ProductsController < ApplicationController
     sanitized_and_split_query_array = Product.sanitize_sql_like(params[:query]).split.map { |keyword| '%' + keyword + '%' }
     @products = sanitized_and_split_query_array.reduce([]) { |memo, query|
       memo << Product.where('name LIKE ?', query)
+      memo << Product.where('description LIKE ?', query)
+      memo << Product.where('brand LIKE ?', query)
+      memo << Product.where('sku LIKE ?', query)
     }.flatten
     @products = @products.filter(&:on_shelf?) unless admin_signed_in? || @products.empty?
     render 'home/index'

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,5 +1,2 @@
 class ApplicationService
-  def self.process_cart(*args, &blocks)
-    new(*args, &blocks).process_cart
-  end
 end

--- a/app/services/payment.rb
+++ b/app/services/payment.rb
@@ -1,0 +1,5 @@
+class Payment < ApplicationService 
+  def self.process_cart(*args, &blocks)
+    new(*args, &blocks).process_cart
+  end
+end

--- a/app/services/search.rb
+++ b/app/services/search.rb
@@ -1,0 +1,11 @@
+class Search < ApplicationService 
+  def self.products(query)
+    sanitized_and_split_query_array = Product.sanitize_sql_like(query).split.map { |keyword| '%' + keyword + '%' }
+    @products = sanitized_and_split_query_array.reduce([]) { |memo, query|
+                memo << Product.where('name LIKE ?', query)
+                memo << Product.where('description LIKE ?', query)
+                memo << Product.where('brand LIKE ?', query)
+                memo << Product.where('sku LIKE ?', query)
+    }.flatten
+  end
+end

--- a/app/services/search.rb
+++ b/app/services/search.rb
@@ -1,11 +1,36 @@
 class Search < ApplicationService 
-  def self.products(query)
-    sanitized_and_split_query_array = Product.sanitize_sql_like(query).split.map { |keyword| '%' + keyword + '%' }
-    @products = sanitized_and_split_query_array.reduce([]) { |memo, query|
-                memo << Product.where('name LIKE ?', query)
-                memo << Product.where('description LIKE ?', query)
-                memo << Product.where('brand LIKE ?', query)
-                memo << Product.where('sku LIKE ?', query)
+  attr_reader :query, :original_query
+
+  def initialize(query)
+    @original_query = query + '' # the addition forces saving a copy
+    @query = sanitize_query(query)
+  end
+
+  def inside_products
+    keywords = self.split_keywords
+    products = keywords.reduce([]) { |memo, query|
+      query = '%' + query + '%'
+      memo << Product.where('name LIKE ?', query)
+      memo << Product.where('description LIKE ?', query)
+      memo << Product.where('brand LIKE ?', query)
+      memo << Product.where('sku LIKE ?', query)
     }.flatten
+  end
+
+  def sanitize_query(str)
+    str.gsub!('%', '')
+    str.scan(/\S+_\S+/).each { |connected_word| str.gsub!(connected_word, '"' + connected_word + '"')}
+    str.gsub!('_', ' ') 
+    @query = str
+  end
+
+  def split_keywords
+    query = @query + '' # the addition forces a copy of @query
+    phrases = query.scan(/"([^"]*)"/).flatten
+    phrases.each do |phrase|
+      query.gsub!('"' + phrase + '"', '') # temporarily remove phrases
+    end
+    single_keywords = query.split
+    single_keywords + phrases
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <section>
   <h1>Produtos</h1>
   <% if @products.empty? %>
-      <p>Não existem produtos cadastrados</p>
+      <p><%= @message_if_empty %></p>
   <% else %>
     <% @products.each do |product| %>
       <article>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -6,21 +6,18 @@
     </button>
 
     <div class="collapse navbar-collapse row d-flex justify-content-center search-bar">
-      <div class="input-group">
-        
-        <div class="input-group-text p-0">
-          <select class="form-select form-select shadow-none bg-light border-0">
-            <option>Categorias</option>
-            <% ProductCategory.all.each do |category| %>
-              <option value="<%= category.id %>"><%= category.name %></option>
-            <% end %>
-          </select>
-        </div>
-        <%= form_with url: search_products_path, method: :get, class: "d-flex" do |form| %>
-          <%= form.text_field :query, class: "form-control", placeholder: "Busque aqui seu produto" %>
+        <%= form_with url: search_products_path, method: :get, class: "d-flex form-inline input-group" do |form| %>
+          <div class="input-group-text p-0">
+            <select class="form-select form-select shadow-none bg-light border-0">
+              <option>Categorias</option>
+              <% ProductCategory.all.each do |category| %>
+                <option value="<%= category.id %>"><%= category.name %></option>
+              <% end %>
+            </select>
+          </div>
+          <%= form.text_field :query, class: "form-control mr-sm-2", type: "search", placeholder: "Busque aqui seu produto" %>
           <%= form.submit "Procurar", class: "btn btn-warning input-group-text shadow-none px-4" %>
         <% end %>
-      </div>
     </div>
 
     <ul class="navbar-nav">

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -16,10 +16,10 @@
             <% end %>
           </select>
         </div>
-        <input type="text" class="form-control" placeholder="Busque aqui seu produto">
-        <button class="btn btn-warning input-group-text shadow-none px-4">
-          Procurar
-        </button>
+        <%= form_with url: search_products_path, method: :get, class: "d-flex" do |form| %>
+          <%= form.text_field :query, class: "form-control", placeholder: "Busque aqui seu produto" %>
+          <%= form.submit "Procurar", class: "btn btn-warning input-group-text shadow-none px-4" %>
+        <% end %>
       </div>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   resources :products, only: [:show] do
     post 'update_status', on: :member
+    get 'search', on: :collection
   end
   resources :product_categories, only: [:index, :show, :new, :create, :edit, :update]
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,40 +2,36 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-# Create products and prices
+p 'Create products and prices'
 product1 = Product.create!(status: 'on_shelf',
   name: 'Caneca Mon Amour', brand: 'TOC & Ex-TOC', sku: 'TOC1234',
-  description: 'Caneca em cerâmica com desenho de uma flecha do cupido')
-Price.create!(product: product1, price_in_brl: 10.00, validity_start: 1.second.from_now)
+  description: 'Caneca em cerâmica com desenho de uma flecha do cupido').set_price(10)
 
 product2 = Product.create!(status: 'on_shelf',
   name: 'Garrafa Star Wars', brand: 'Zona Criativa', sku: 'ZON0001',
   description: 'Garrafa térmica inox, star wars')
-Price.create!(product: product2, price_in_brl: 25.99, validity_start: 1.second.from_now)
+Price.create!(product: product2, price_in_brl: 25.99, validity_start: Time.current)
 Price.create!(product: product2, price_in_brl: 19.99, validity_start: 2.weeks.from_now)
 Price.create!(product: product2, price_in_brl: 27.99, validity_start: 3.weeks.from_now)
 
 product3 = Product.create!(status: 'off_shelf',
   name: 'Camisa Blue Sky', sku: 'VES1234', brand: 'Vestil',
-  description: 'Camisa de algodão com estampa de céu e nuvens.')
-Price.create!(product: product3, price_in_brl: 20.00, validity_start: 1.second.from_now)
+  description: 'Camisa de algodão com estampa de céu e nuvens.').set_price(20)
 
 product4 = Product.create!(status: 'draft',
   name: 'Camisa Green Forest', sku: 'VES4321',
-  brand: 'Vestil',description: 'Camisa de algodão com estampa de floresta.')
-Price.create!(product: product4, price_in_brl: 90.00, validity_start: 1.second.from_now)
+  brand: 'Vestil',description: 'Camisa de algodão com estampa de floresta.').set_price(90)
 
 product5 = Product.create!(status: 'on_shelf',
   name: 'Camisa Large Sea', sku: 'VES2321',
-  brand: 'Vestil',description: 'Camisa de algodão com estampa do mar com ondas.')
-Price.create!(product: product5, price_in_brl: 89.00, validity_start: 1.second.from_now)
+  brand: 'Vestil',description: 'Camisa de algodão com estampa do mar com ondas.').set_price(89)
 
-# Create log-ins
+p 'Create log-ins'
 Admin.create(email: 'claudia@mercadores.com.br', password: '123456', name: 'Claudia Ferreira')
 admin = Admin.create(email: 'manoel@mercadores.com.br', password: '123456', name: 'Manoel da Silva')
 user = User.create(email: 'joaquim@meuemail.com.br', password: '123456', name: 'Joaquim Santos')
 
-# Create ProductCategory
+p 'Create Product categories'
 eletronicos = ProductCategory.create(name: "Eletrônicos")
 informatica = ProductCategory.create(name: "Informática", parent: eletronicos)
 notebooks = ProductCategory.create(name: "Notebooks", parent: informatica)
@@ -54,13 +50,14 @@ moveis = ProductCategory.create(name: "Móveis")
 mesa_escritorio = ProductCategory.create(name: "Mesa de Escritório", parent: moveis)
 guarda_roupa = ProductCategory.create(name: "Guarda-roupa", parent: moveis)
 
-# Create Carts and Orders
+p 'Create Carts and Orders'
 CartItem.create!(product: product1, quantity: 5, user: user )
 CartItem.create!(product: product2, quantity: 7, user: user )
 Order.create!(address: 'Rua da entrega, 75', user: user)
 CartItem.create!(product: product3, quantity: 5, user: user )
 CartItem.create!(product: product1, quantity: 7, user: user )
 
+p 'Sumário'
 p "Foram criados #{Admin.count} admins"
 p "Foram criados #{User.count} usuários"
 p "Foram criados #{Product.count} produtos"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,43 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-p 'Create products and prices'
+puts "\n---- cria um monte de cacarecos  ------"
+
+names_and_descriptions = [
+  # ['', ''], 
+  ['Caneca Sabre de Luz', 'Caneca em cerâmica com desenho de sabre de luz que se acende quando a caneca está quente.'],
+  ['Xícara Levitadora', 'Par de duas xícaras em vidro transparente com parede dupla. Parece que seu café está flutuando!'],
+  ['Conjunto Tóquio', 'Conjunto para chá em estilo japonês, feito inteiramente em ecoplástico e composto de 4 xícaras pequenas sem alça.'],
+  ['Pano das Galáxias', 'Pano de prato 100% algodão, na cor preta com desenhos de estrelas e cometas.'],
+  ['Caneca-bolo', 'Caneca em cerâmica com impressão de receita de bolo de caneca. Acompanha sachê com mistura para bolo, basta acrescentar água.'],
+  ['Copo Sujo', 'Conjunto de 4 copos de 200ml iguaizinhos ao do boteco da esquina.'],
+  ['Copo Sujo Super Power', 'Conjunto de 2 copos como os do boteco da esquina, mas de 400ml.'],
+  ['Protetor de mesa Bar do Lado', 'Conjunto de 5 protetores de mesa, também conhecidos como coasters, com impressões de rótulos de cervejas famosas'],
+  ['Copo Colapsável EcoOffice', 'Nunca mais fique sem copo no bebedouro de galão! Este copo de 300ml se contrai a um disco que cabe em qualquer bolso. Aproveite esta novidade!'],
+  ['Codando Loucamente', 'Caneca com os dizeres "Talking is cheap, show me the code" em formatação de código'], 
+  ['Adesivos Grumpy Bear', 'Cartela de adesivos do Brown, o urso rabugento mais fofo que você conhece, e seu novo contatinho Cony a Coelha. Mas não conte pra ninguém que eles estão saindo, ainda é segredo!'], 
+  ['Fancy Napkings Silk Edition', 'Um lindo lenço branco rendado, em estilo vintage'], 
+  ['Love Book - A Luz', 'Fofíssima luminária led para livros, com garra para prender na capa, em forma de coração (que você nunca vai usar mesmo porque o último livro que você leu foi para prestar vestibular)'], 
+  ['Pires Chá das 5', 'Pires de reposição para a Xícara Chá das 5'], 
+  ['Xícara Chá das 5', 'Elegante xícara em fina cerâmica, para momentos elegantes ao tomar chá ou café.'], 
+  ['Moonbucks', 'No melhor estilo das grandes lojas de café, este copo para bebidas quentes tem uma tampa de pequeno orifício, que permite tomar café em movimento sem se sujar.'], 
+  ['Caneca Coffee Lovers', 'Eu moo, tu fazes o café, nós tomamos! Esta caneca não pode faltar na sua mesa de café da manhã!'], 
+  ['Caneca Térmica Hot Forever', 'Linda caneca térmica em aço inox, para compor um belo ambiente de trabalho na sua mesa de home office e ser ostentada furtivamente durante suas vídeo-conferências'], 
+]
+
+brands = ['Pensaminarium', 'Vesúvia', 'TOC & ex-TOC']
+
+names_and_descriptions.each do | pair |
+  Product.create(status: 'on_shelf',
+                name: pair[0], 
+                description: pair[1], 
+                brand: brands[rand(brands.size)],
+                sku: ('a'..'z').to_a.shuffle[0..1].join.upcase + (SecureRandom.random_number * 10**7).to_i.to_s,
+  ).set_price(14 * (1 + rand(100)/100.0).truncate(2))
+end
+
+puts '----- cria mais produtos e preços -----'
+
 product1 = Product.create!(status: 'on_shelf',
   name: 'Caneca Mon Amour', brand: 'TOC & Ex-TOC', sku: 'TOC1234',
   description: 'Caneca em cerâmica com desenho de uma flecha do cupido').set_price(10)
@@ -26,12 +62,15 @@ product5 = Product.create!(status: 'on_shelf',
   name: 'Camisa Large Sea', sku: 'VES2321',
   brand: 'Vestil',description: 'Camisa de algodão com estampa do mar com ondas.').set_price(89)
 
-p 'Create log-ins'
+
+puts '----- cria cadastros de usuários ------'
+
 Admin.create(email: 'claudia@mercadores.com.br', password: '123456', name: 'Claudia Ferreira')
 admin = Admin.create(email: 'manoel@mercadores.com.br', password: '123456', name: 'Manoel da Silva')
 user = User.create(email: 'joaquim@meuemail.com.br', password: '123456', name: 'Joaquim Santos')
 
-p 'Create Product categories'
+puts '----- cria categorias de produtos -----'
+
 eletronicos = ProductCategory.create(name: "Eletrônicos")
 informatica = ProductCategory.create(name: "Informática", parent: eletronicos)
 notebooks = ProductCategory.create(name: "Notebooks", parent: informatica)
@@ -50,18 +89,20 @@ moveis = ProductCategory.create(name: "Móveis")
 mesa_escritorio = ProductCategory.create(name: "Mesa de Escritório", parent: moveis)
 guarda_roupa = ProductCategory.create(name: "Guarda-roupa", parent: moveis)
 
-p 'Create Carts and Orders'
+puts '----------- cria pedidos --------------'
+
 CartItem.create!(product: product1, quantity: 5, user: user )
 CartItem.create!(product: product2, quantity: 7, user: user )
 Order.create!(address: 'Rua da entrega, 75', user: user)
 CartItem.create!(product: product3, quantity: 5, user: user )
 CartItem.create!(product: product1, quantity: 7, user: user )
 
-p 'Sumário'
-p "Foram criados #{Admin.count} admins"
-p "Foram criados #{User.count} usuários"
-p "Foram criados #{Product.count} produtos"
-p "Foram criados um total de #{Price.count} preços para #{Price.select(:product_id).distinct.count} produtos"
-p "Foram criadas #{ProductCategory.count} categorias de produtos"
-p "Foram criadas #{CartItem.count} instâncias de item de carrinho"
-p "Foram criadas #{Order.count} instâncias de pedidos"
+
+puts "\nSumário"
+puts "Foram criados #{Admin.count} admins"
+puts "Foram criados #{User.count} cadastros de clientes"
+puts "Foram criados #{Product.count} produtos"
+puts "Foram criados um total de #{Price.count} preços para #{Price.select(:product_id).distinct.count} produtos"
+puts "Foram criadas #{ProductCategory.count} categorias de produtos"
+puts "Foram colocados #{CartItem.count} itens em carrinhos"
+puts "Foram criados #{Order.count} pedidos"

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,0 +1,177 @@
+require 'rails_helper'
+
+RSpec.describe Search, type: :feature do
+  describe '.new' do
+    it 'should instatiate a new Search' do
+      # result = Search.new(query: 'chocolate') # por que não funciona?
+      result = Search.new('chocolate') 
+
+      expect(result).to be_instance_of Search
+      expect(result.query).to eq 'chocolate'
+    end
+  end
+
+  describe '#sanitize_query' do
+    it 'should remove percentage signs (%)' do
+      # note that @query is saved sanitized, as opposed to @original_query
+      search = Search.new('"chocolate branco" % café "leite condensado"')
+
+      expect(search.query.class).to be String
+      expect(search.query).to eq '"chocolate branco"  café "leite condensado"'
+    end
+
+    it 'should remove underscore signs (_) in the beginning or ending of words' do
+      search = Search.new('chocolate_branco café "leite condensado"')
+
+      expect(search.query).to eq '"chocolate branco" café "leite condensado"'
+    end
+
+    it 'should substitute underscore signs (_) by spaces and apply quotes' do
+      search = Search.new('chocolate_branco café "leite condensado"')
+
+      expect(search.query).to eq '"chocolate branco" café "leite condensado"'
+    end
+
+    it 'should not change the original query' do
+      search = Search.new('_chocolate branco % "leite condensado"')
+
+      expect(search.original_query).to eq '_chocolate branco % "leite condensado"'
+    end
+  end
+
+  describe '#split_keywords' do
+    it 'should return an array of keywords' do
+      result = Search.new('chocolate branco').split_keywords
+
+      expect(result.class).to be Array
+      expect(result).to eq ['chocolate', 'branco']
+    end
+
+    it 'should respect expressions inside quotation marks' do
+      search = Search.new('"chocolate branco" café "leite condensado"')
+
+      result = search.split_keywords
+
+      expect(result).to include 'chocolate branco'
+      expect(result).to include 'leite condensado'
+      expect(result).to include 'café'
+      expect(result.size).to eq 3
+    end
+
+    it 'should not change the original query' do
+      search = Search.new('chocolate branco "leite condensado"')
+
+      result = search.split_keywords
+
+      expect(search.original_query).to eq 'chocolate branco "leite condensado"'
+    end
+  end
+
+  describe '#inside_products' do
+    it 'should find products by name, regardless of letter case' do
+      product1 = create(:product, name: 'Prancha de Surf')
+      product2 = create(:product, name: 'Wetsuit para SURF')
+      product3 = create(:product, name: 'Malucos do kitesurf')
+      product4 = create(:product, name: 'Caneca de café')
+      
+      results = Search.new('surf').inside_products
+
+      expect(results).to include product1
+      expect(results).to include product2
+      expect(results).to include product3
+      expect(results).not_to include product4
+    end
+
+    it 'should find products by description, regardless of letter case' do
+      product1 = create(:product, description: 'Prancha para surfar')
+      product2 = create(:product, description: 'Feito de neoprene para o melhor SURF')
+      product3 = create(:product, description: 'A história dos primeiros kitesurfistas do mundo')
+      product4 = create(:product, description: 'Uma caneca de café')
+      
+      results = Search.new('surf').inside_products
+
+      expect(results).to include product1
+      expect(results).to include product2
+      expect(results).to include product3
+      expect(results).not_to include product4
+    end
+
+    it 'should find products by brand, regardless of letter case' do
+      product1 = create(:product, brand: 'Surf Maravilha')
+      product2 = create(:product, brand: 'SURF me')
+      product3 = create(:product, brand: 'editora amigos do surf')
+      product4 = create(:product, brand: 'TOC & ex-TOC')
+      
+      results = Search.new('surf').inside_products
+
+      expect(results).to include product1
+      expect(results).to include product2
+      expect(results).to include product3
+      expect(results).not_to include product4
+    end
+
+    it 'should find products by SKU, regardless of letter case' do
+      product3 = create(:product, sku: 'SURF32543')
+      product4 = create(:product, sku: 'CANECA998')
+      
+      results = Search.new('surf').inside_products
+
+      expect(results).to include product3
+      expect(results).not_to include product4
+    end
+
+    it 'should find products regardless of their status' do
+      product1 = create(:product, status: 'off_shelf',name: 'Malucos do kitesurf')
+      product2 = create(:product, status: 'draft',    description: 'Prancha para surfar')
+      product3 = create(:product, status: 'on_shelf', brand: 'Surf Maravilha')
+      product4 = create(:product, status: 'on_shelf', sku: 'SURF32543')
+      product5 = create(:product, status: 'on_shelf', name: 'Caneca de café')
+      
+      results = Search.new('surf').inside_products
+
+      expect(results).to include product1
+      expect(results).to include product2
+      expect(results).to include product3
+      expect(results).to include product4
+      expect(results).not_to include product5
+    end
+
+    it 'should work for expressions' do
+      product1 = create(:product, name: 'Café com caneca de brinde')
+      product2 = create(:product, name: 'Caneca Mon Amour com pires')
+      
+      results = Search.new('"com caneca"').inside_products
+
+      expect(results).to include product1
+      expect(results).not_to include product2
+    end
+
+    it 'should work for multiple keywords' do
+      product1 = create(:product, description: 'short')
+      product2 = create(:product, description: 'neoprene')
+      product3 = create(:product, description: 'short em neoprene')
+      product4 = create(:product, description: 'Uma caneca de café')
+      
+      results = Search.new('short neoprene').inside_products
+
+      expect(results).to include product1
+      expect(results).to include product2
+      expect(results).to include product3
+      expect(results).not_to include product4
+    end
+
+    it 'should work for multiple keywords and phrases together' do
+      product1 = create(:product, description: 'short em tactel para surfar')
+      product2 = create(:product, description: 'surf')
+      product3 = create(:product, description: 'short em neoprene para kitesurf')
+      product4 = create(:product, description: 'Uma caneca de café')
+      
+      results = Search.new('surf "short em"').inside_products
+
+      expect(results).to include product1
+      expect(results).to include product2
+      expect(results).to include product3
+      expect(results).not_to include product4
+    end
+  end
+end

--- a/spec/system/authentication/admin_logs_in_spec.rb
+++ b/spec/system/authentication/admin_logs_in_spec.rb
@@ -5,7 +5,7 @@ describe 'Unlogged user logs in as an admin' do
     create(:admin, name: 'João do Rêgo')
 
     visit new_admin_session_path
-    within 'form' do
+    within '.form-signin' do
       fill_in 'E-mail', with: 'joao@mercadores.com.br'
       fill_in 'Senha', with: '123456'
       click_on 'Entrar'
@@ -19,7 +19,7 @@ describe 'Unlogged user logs in as an admin' do
     create(:admin, name: 'João do Rêgo', password: '123456')
       
     visit new_admin_session_path
-    within 'form' do
+    within '.form-signin' do
       fill_in 'E-mail', with: 'joao@mercadores.com.br'
       fill_in 'Senha', with: '9999999'
       click_on 'Entrar'

--- a/spec/system/authentication/user_logs_in_spec.rb
+++ b/spec/system/authentication/user_logs_in_spec.rb
@@ -8,7 +8,7 @@ describe 'Unlogged user logs in as a costumer' do
     within('nav') do
       click_on 'Entrar'
     end
-    within('form') do
+    within('.form-signin') do
       fill_in 'E-mail', with: 'jose@meuemail.com'
       fill_in 'Senha', with: '123456'
       click_on 'Entrar'
@@ -23,7 +23,7 @@ describe 'Unlogged user logs in as a costumer' do
       
     visit root_path
     click_on 'Entrar'
-    within 'form' do
+    within '.form-signin' do
       fill_in 'E-mail', with: 'jose@meuemail.com'
       fill_in 'Senha', with: '9999999'
       click_on 'Entrar'

--- a/spec/system/product/anyone_searches_products_spec.rb
+++ b/spec/system/product/anyone_searches_products_spec.rb
@@ -5,37 +5,32 @@ feature 'Using the search function on the navbar,' do
     it 'returns all matching products regardless of their status' do
       admin = create(:admin)
       product1 = create(:product, status: 'off_shelf',name: 'Pracha de surf')
-      product2 = create(:product, status: 'draft',    name: 'Twilight Patrol - Wetsuit para Surf')
-      product3 = create(:product, status: 'on_shelf', name: 'Malucos do kitesurf - uma biografia')
-      product4 = create(:product, status: 'on_shelf', name: 'Camiseta com onda', description: 'Camiseta 100% algodão com motivos de surf')
-      product5 = create(:product, status: 'on_shelf', name: 'Boardshort com bolso', brand: 'Surf me')
-      product6 = create(:product, status: 'on_shelf', name: 'Parafina', sku: 'SURF9045')
-      unrelated_product = create(:product, name: 'Caneca Mon Amour', 
-                                            status: 'on_shelf',
-                                            brand: 'TOC & Ex-TOC',
-                                            description: 'Caneca em cerâmica com desenho de uma flecha do cupido',
-                                            sku: 'TOCCAN1234')
+      product2 = create(:product, status: 'draft',    description: 'Wetsuit para Surf')
+      product3 = create(:product, status: 'on_shelf', brand: 'Surf me')
+      unrelated_product = create(:product, name: 'Caneca Morning Coffee', 
+                                           status: 'on_shelf',
+                                           brand: 'TOC & Ex-TOC',
+                                           description: 'Caneca em cerâmica',
+                                           sku: 'TOCCAN1234')
 
       login_as(admin, scope: :admin)
       visit root_path
       fill_in 'Busque aqui seu produto', with: 'surf'
       click_on 'Procurar'
 
-      expect(page).to have_text(product1.name) # off_shelf | keyword on title
-      expect(page).to have_text(product2.name) # draft     | keyword on title
-      expect(page).to have_text(product3.name) # on_shelf  | keyword on title, part of another word 
-      expect(page).to have_text(product4.name) # lowercase | keyword on description
-      expect(page).to have_text(product5.name) # mixed case| keyword on brand
-      expect(page).to have_text(product6.name) # uppercase | keyword on SKU
+      expect(page).to have_text(product1.name) 
+      expect(page).to have_text(product2.name)
+      expect(page).to have_text(product3.name)
       expect(page).not_to have_text(unrelated_product.name)
     end
   end
 
   context 'when done by a logged user' do
-    it 'returns only matching products on shelf' do
+    it 'returns only matching products that are on shelf' do
       product1 = create(:product, status: 'on_shelf',  name: 'Caneca Mon Amour')
-      product2 = create(:product, status: 'draft',     name: 'Caneca Santo Café Diário')
-      product3 = create(:product, status: 'off_shelf', name: 'Caneca Moonbucks')
+      product2 = create(:product, status: 'on_shelf',  name: 'Café com caneca de brinde')
+      product3 = create(:product, status: 'draft',     name: 'Caneca Santo Café Diário')
+      product4 = create(:product, status: 'off_shelf', name: 'Caneca Moonbucks')
       user = create(:user)
 
       login_as(user, scope: :user)
@@ -44,8 +39,9 @@ feature 'Using the search function on the navbar,' do
       click_on 'Procurar'
 
       expect(page).to have_text(product1.name)
-      expect(page).not_to have_text(product2.name)
+      expect(page).to have_text(product2.name)
       expect(page).not_to have_text(product3.name)
+      expect(page).not_to have_text(product4.name)
     end
   end
 end

--- a/spec/system/product/anyone_searches_products_spec.rb
+++ b/spec/system/product/anyone_searches_products_spec.rb
@@ -43,5 +43,13 @@ feature 'Using the search function on the navbar,' do
       expect(page).not_to have_text(product3.name)
       expect(page).not_to have_text(product4.name)
     end
+
+    it 'returns message if no products are found' do
+      visit root_path
+      fill_in 'Busque aqui seu produto', with: 'chocolate branco'
+      click_on 'Procurar'
+
+      expect(page).to have_text('Nenhum resultado encontrado para: chocolate branco')
+    end
   end
 end

--- a/spec/system/product/anyone_searches_products_spec.rb
+++ b/spec/system/product/anyone_searches_products_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+feature 'Using the search function on the navbar,' do
+  context 'when done by an admin,' do
+    it 'returns all matching products regardless of their status' do
+      product1 = create(:product, name: 'Caneca Mon Amour', 
+                                  status: 'on_shelf',
+                                  brand: 'TOC & Ex-TOC',
+                                  description: 'Caneca em cerâmica com desenho de uma flecha do cupido',
+                                  sku: 'TOCCAN1234')
+      product2 = create(:product, name: 'Caneca Santo Café Diário', 
+                                  status: 'draft',
+                                  brand: 'Vesúvia',
+                                  description: 'Caneca em vidro dupla face, ideal para cappuccinos',
+                                  sku: 'VES38502')
+      product3 = create(:product, name: 'Camiseta Verde-Água', 
+                                  status: 'on_shelf',
+                                  brand: 'RIP Curva',
+                                  description: 'Camiseta 100% algodão com desenho uma caneca',
+                                  sku: 'RIP00748')
+      admin = create(:admin)
+
+      login_as(admin, scope: :admin)
+      visit root_path
+      fill_in 'Busque aqui seu produto', with: 'Caneca'
+      click_on 'Procurar'
+
+      expect(page).to have_text('Caneca Mon Amour')
+      expect(page).to have_text('Caneca Santo Café Diário')
+      expect(page).not_to have_text('Camiseta')
+    end
+  end
+
+  context 'when done by a logged user' do
+    it 'returns only matching products on shelf' do
+      product1 = create(:product, name: 'Caneca Mon Amour', 
+                                  status: 'on_shelf',
+                                  brand: 'TOC & Ex-TOC',
+                                  description: 'Caneca em cerâmica com desenho de uma flecha do cupido',
+                                  sku: 'TOCCAN1234')
+      product2 = create(:product, name: 'Caneca Santo Café Diário', 
+                                  status: 'draft',
+                                  brand: 'Vesúvia',
+                                  description: 'Caneca em vidro dupla face, ideal para cappuccinos',
+                                  sku: 'VES38502')
+      product3 = create(:product, name: 'Camiseta Verde-Água', 
+                                  status: 'on_shelf',
+                                  brand: 'RIP Curva',
+                                  description: 'Camiseta 100% algodão com desenho uma caneca',
+                                  sku: 'RIP00748')
+      user = create(:user)
+
+      login_as(user, scope: :user)
+      visit root_path
+      fill_in 'Busque aqui seu produto', with: 'Caneca'
+      click_on 'Procurar'
+
+      expect(page).to have_text('Caneca Mon Amour')
+      expect(page).not_to have_text('Caneca Santo Café Diário')
+      expect(page).not_to have_text('Camiseta')
+    end
+  end
+end

--- a/spec/system/product/anyone_searches_products_spec.rb
+++ b/spec/system/product/anyone_searches_products_spec.rb
@@ -3,51 +3,39 @@ require 'rails_helper'
 feature 'Using the search function on the navbar,' do
   context 'when done by an admin,' do
     it 'returns all matching products regardless of their status' do
-      product1 = create(:product, name: 'Caneca Mon Amour', 
-                                  status: 'on_shelf',
-                                  brand: 'TOC & Ex-TOC',
-                                  description: 'Caneca em cerâmica com desenho de uma flecha do cupido',
-                                  sku: 'TOCCAN1234')
-      product2 = create(:product, name: 'Caneca Santo Café Diário', 
-                                  status: 'draft',
-                                  brand: 'Vesúvia',
-                                  description: 'Caneca em vidro dupla face, ideal para cappuccinos',
-                                  sku: 'VES38502')
-      product3 = create(:product, name: 'Camiseta Verde-Água', 
-                                  status: 'on_shelf',
-                                  brand: 'RIP Curva',
-                                  description: 'Camiseta 100% algodão com desenho uma caneca',
-                                  sku: 'RIP00748')
       admin = create(:admin)
+      product1 = create(:product, status: 'off_shelf',name: 'Pracha de surf')
+      product2 = create(:product, status: 'draft',    name: 'Twilight Patrol - Wetsuit para Surf')
+      product3 = create(:product, status: 'on_shelf', name: 'Malucos do kitesurf - uma biografia')
+      product4 = create(:product, status: 'on_shelf', name: 'Camiseta com onda', description: 'Camiseta 100% algodão com motivos de surf')
+      product5 = create(:product, status: 'on_shelf', name: 'Boardshort com bolso', brand: 'Surf me')
+      product6 = create(:product, status: 'on_shelf', name: 'Parafina', sku: 'SURF9045')
+      unrelated_product = create(:product, name: 'Caneca Mon Amour', 
+                                            status: 'on_shelf',
+                                            brand: 'TOC & Ex-TOC',
+                                            description: 'Caneca em cerâmica com desenho de uma flecha do cupido',
+                                            sku: 'TOCCAN1234')
 
       login_as(admin, scope: :admin)
       visit root_path
-      fill_in 'Busque aqui seu produto', with: 'Caneca'
+      fill_in 'Busque aqui seu produto', with: 'surf'
       click_on 'Procurar'
 
-      expect(page).to have_text('Caneca Mon Amour')
-      expect(page).to have_text('Caneca Santo Café Diário')
-      expect(page).not_to have_text('Camiseta')
+      expect(page).to have_text(product1.name) # off_shelf | keyword on title
+      expect(page).to have_text(product2.name) # draft     | keyword on title
+      expect(page).to have_text(product3.name) # on_shelf  | keyword on title, part of another word 
+      expect(page).to have_text(product4.name) # lowercase | keyword on description
+      expect(page).to have_text(product5.name) # mixed case| keyword on brand
+      expect(page).to have_text(product6.name) # uppercase | keyword on SKU
+      expect(page).not_to have_text(unrelated_product.name)
     end
   end
 
   context 'when done by a logged user' do
     it 'returns only matching products on shelf' do
-      product1 = create(:product, name: 'Caneca Mon Amour', 
-                                  status: 'on_shelf',
-                                  brand: 'TOC & Ex-TOC',
-                                  description: 'Caneca em cerâmica com desenho de uma flecha do cupido',
-                                  sku: 'TOCCAN1234')
-      product2 = create(:product, name: 'Caneca Santo Café Diário', 
-                                  status: 'draft',
-                                  brand: 'Vesúvia',
-                                  description: 'Caneca em vidro dupla face, ideal para cappuccinos',
-                                  sku: 'VES38502')
-      product3 = create(:product, name: 'Camiseta Verde-Água', 
-                                  status: 'on_shelf',
-                                  brand: 'RIP Curva',
-                                  description: 'Camiseta 100% algodão com desenho uma caneca',
-                                  sku: 'RIP00748')
+      product1 = create(:product, status: 'on_shelf',  name: 'Caneca Mon Amour')
+      product2 = create(:product, status: 'draft',     name: 'Caneca Santo Café Diário')
+      product3 = create(:product, status: 'off_shelf', name: 'Caneca Moonbucks')
       user = create(:user)
 
       login_as(user, scope: :user)
@@ -55,9 +43,9 @@ feature 'Using the search function on the navbar,' do
       fill_in 'Busque aqui seu produto', with: 'Caneca'
       click_on 'Procurar'
 
-      expect(page).to have_text('Caneca Mon Amour')
-      expect(page).not_to have_text('Caneca Santo Café Diário')
-      expect(page).not_to have_text('Camiseta')
+      expect(page).to have_text(product1.name)
+      expect(page).not_to have_text(product2.name)
+      expect(page).not_to have_text(product3.name)
     end
   end
 end


### PR DESCRIPTION
Em relação com a issue
- #33

Implementa pesquisa na navbar do site que considera os campos nome, descrição, marca e SKU de um produto.

Os resultados são renderizados na homepage, então existe uma questão sobre como seria para o admin. **Sugestão: que o admin tenha um dashboard**, ou qualquer coisa diferente da homepage para visualizar os links de gerenciamento.

A busca foi criada como uma classe que herda de `ApplicationService`, para manter a coerência com a organização do Rails. Os testes dela foram colocados na categoria `feature` porque pareciam não se encaixar nem em `model`, nem em `system`.

Uma busca deve ser instanciada através de `Search.new(query)`. Dentro dela se grava a query original e a query processada para remover símbolos que conflitam com o banco de dados.

A busca por produtos tem seu próprio método: `Search.new(query).inside_products`. Essa organização foi pensada para facilitar a implementação futura de buscas em outros modelos (ex: por pedidos, `#inside_orders`).

A única alteração de exibição foi para quando não há resultados encontrados, conforme abaixo:
<img width="896" alt="product_not_found" src="https://user-images.githubusercontent.com/31296669/174456495-ce5d4c5e-59f2-4066-b70c-0c17e6b25ba4.png">