### PR TITLE
Resolve bug pesquisa duplicada

### DIFF
--- a/app/services/search.rb
+++ b/app/services/search.rb
@@ -14,7 +14,7 @@ class Search < ApplicationService
       memo << Product.where('description LIKE ?', query)
       memo << Product.where('brand LIKE ?', query)
       memo << Product.where('sku LIKE ?', query)
-    }.flatten
+    }.flatten.uniq.sort_by(&:name)
   end
 
   def sanitize_query(str)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,63 +12,64 @@ user = User.create(email: 'joaquim@meuemail.com.br', password: '123456', name: '
 puts '----- cria categorias de produtos -----'
 
 eletronicos = ProductCategory.create(name: "Eletrônicos")
-informatica = ProductCategory.create(name: "Informática", parent: eletronicos)
-notebooks = ProductCategory.create(name: "Notebooks", parent: informatica)
-ultrafinos = ProductCategory.create(name: "Notebooks", parent: notebooks)
-macbook = ProductCategory.create(name: "Notebooks", parent: macbook)
-desktops = ProductCategory.create(name: "Desktops", parent: informatica)
-smartphones = ProductCategory.create(name: "Smartphones", parent: eletronicos)
+  smartphones = ProductCategory.create(name: "Smartphones", parent: eletronicos)
+  informatica = ProductCategory.create(name: "Informática", parent: eletronicos)
+    desktops = ProductCategory.create(name: "Desktops", parent: informatica)
+    notebooks = ProductCategory.create(name: "Notebooks", parent: informatica)
+      ultrafinos = ProductCategory.create(name: "Notebooks", parent: notebooks)
+        macbook = ProductCategory.create(name: "Notebooks", parent: macbook)
 
 eletrodomesticos = ProductCategory.create(name: "Eletrodomésticos")
-lavar_e_secar = ProductCategory.create(name: "Lavar e Secar", parent: eletrodomesticos)
-geladeiras = ProductCategory.create(name: "Geladeiras", parent: eletrodomesticos)
-fogao = ProductCategory.create(name: "Fogão", parent: eletrodomesticos)
-ar_e_ventilacao = ProductCategory.create(name: "Ar e Ventilação", parent: eletrodomesticos)
+  lavar_e_secar = ProductCategory.create(name: "Lavar e Secar", parent: eletrodomesticos)
+  geladeiras = ProductCategory.create(name: "Geladeiras", parent: eletrodomesticos)
+  fogao = ProductCategory.create(name: "Fogão", parent: eletrodomesticos)
+  ar_e_ventilacao = ProductCategory.create(name: "Ar e Ventilação", parent: eletrodomesticos)
 
 moveis = ProductCategory.create(name: "Móveis")
-mesa_escritorio = ProductCategory.create(name: "Mesa de Escritório", parent: moveis)
-guarda_roupa = ProductCategory.create(name: "Guarda-roupa", parent: moveis)
+  mesa_escritorio = ProductCategory.create(name: "Mesa de Escritório", parent: moveis)
+  guarda_roupa = ProductCategory.create(name: "Guarda-roupa", parent: moveis)
 
 utilidades_domesticas = ProductCategory.create(name: "Utilidades Domésticas")
-cafe_e_cha = ProductCategory.create(name: "Café e Chá", parent: utilidades_domesticas)
-garrafas_termicas = ProductCategory.create(name: "Garrafas Térmicas", parent: cafe_e_cha)
-copos_e_canecas = ProductCategory.create(name: "Copos e Canecas", parent: utilidades_domesticas)
-canecas = ProductCategory.create(name: "Canecas", parent: copos_e_canecas)
+  cafe_e_cha = ProductCategory.create(name: "Café e Chá", parent: utilidades_domesticas)
+    garrafas_termicas = ProductCategory.create(name: "Garrafas Térmicas", parent: cafe_e_cha)
+  copos_e_canecas = ProductCategory.create(name: "Copos e Canecas", parent: utilidades_domesticas)
+    canecas = ProductCategory.create(name: "Canecas", parent: copos_e_canecas)
 
 vestuario = ProductCategory.create(name: "Vestuário")
-camisas = ProductCategory.create(name: "Camisas", parent: vestuario)
-camisas_basicas = ProductCategory.create(name: "Camisas Básicas", parent: camisas)
+  camisas = ProductCategory.create(name: "Camisas", parent: vestuario)
+    camisas_basicas = ProductCategory.create(name: "Camisas Básicas", parent: camisas)
 
 puts "---- cria um monte de cacarecos  ------"
 
 names_and_descriptions = [
   # ['', ''], 
-  ['Caneca Sabre de Luz', 'Caneca em cerâmica com desenho de sabre de luz que se acende quando a caneca está quente.'],
-  ['Xícara Levitadora', 'Par de duas xícaras em vidro transparente com parede dupla. Parece que seu café está flutuando!'],
-  ['Conjunto Tóquio', 'Conjunto para chá em estilo japonês, feito inteiramente em ecoplástico e composto de 4 xícaras pequenas sem alça.'],
-  ['Pano das Galáxias', 'Pano de prato 100% algodão, na cor preta com desenhos de estrelas e cometas.'],
-  ['Caneca-bolo', 'Caneca em cerâmica com impressão de receita de bolo de caneca. Acompanha sachê com mistura para bolo, basta acrescentar água.'],
-  ['Copo Sujo', 'Conjunto de 4 copos de 200ml iguaizinhos ao do boteco da esquina.'],
-  ['Copo Sujo Super Power', 'Conjunto de 2 copos como os do boteco da esquina, mas de 400ml.'],
-  ['Protetor de mesa Bar do Lado', 'Conjunto de 5 protetores de mesa, também conhecidos como coasters, com impressões de rótulos de cervejas famosas'],
-  ['Copo Colapsável EcoOffice', 'Nunca mais fique sem copo no bebedouro de galão! Este copo de 300ml se contrai a um disco que cabe em qualquer bolso. Aproveite esta novidade!'],
-  ['Codando Loucamente', 'Caneca com os dizeres "Talking is cheap, show me the code" em formatação de código'], 
-  ['Adesivos Grumpy Bear', 'Cartela de adesivos do Brown, o urso rabugento mais fofo que você conhece, e seu novo contatinho Cony a Coelha. Mas não conte pra ninguém que eles estão saindo, ainda é segredo!'], 
-  ['Fancy Napkings Silk Edition', 'Um lindo lenço branco rendado, em estilo vintage'], 
-  ['Love Book - A Luz', 'Fofíssima luminária led para livros, com garra para prender na capa, em forma de coração (que você nunca vai usar mesmo porque o último livro que você leu foi para prestar vestibular)'], 
-  ['Pires Chá das 5', 'Pires de reposição para a Xícara Chá das 5'], 
-  ['Xícara Chá das 5', 'Elegante xícara em fina cerâmica, para momentos elegantes ao tomar chá ou café.'], 
-  ['Moonbucks', 'No melhor estilo das grandes lojas de café, este copo para bebidas quentes tem uma tampa de pequeno orifício, que permite tomar café em movimento sem se sujar.'], 
-  ['Caneca Coffee Lovers', 'Eu moo, tu fazes o café, nós tomamos! Esta caneca não pode faltar na sua mesa de café da manhã!'], 
-  ['Caneca Térmica Hot Forever', 'Linda caneca térmica em aço inox, para compor um belo ambiente de trabalho na sua mesa de home office e ser ostentada furtivamente durante suas vídeo-conferências'], 
+  [canecas, 'Caneca Sabre de Luz', 'Caneca em cerâmica com desenho de sabre de luz que se acende quando a caneca está quente.'],
+  [cafe_e_cha, 'Xícara Levitadora', 'Par de duas xícaras em vidro transparente com parede dupla. Parece que seu café está flutuando!'],
+  [cafe_e_cha, 'Conjunto Tóquio', 'Conjunto para chá em estilo japonês, feito inteiramente em ecoplástico e composto de 4 xícaras pequenas sem alça.'],
+  [utilidades_domesticas, 'Pano das Galáxias', 'Pano de prato 100% algodão, na cor preta com desenhos de estrelas e cometas.'],
+  [canecas, 'Caneca-bolo', 'Caneca em cerâmica com impressão de receita de bolo de caneca. Acompanha sachê com mistura para bolo, basta acrescentar água.'],
+  [copos_e_canecas, 'Copo Sujo', 'Conjunto de 4 copos de 200ml iguaizinhos ao do boteco da esquina.'],
+  [copos_e_canecas, 'Copo Sujo Super Power', 'Conjunto de 2 copos como os do boteco da esquina, mas de 400ml.'],
+  [utilidades_domesticas, 'Protetor de mesa Bar do Lado', 'Conjunto de 5 protetores de mesa, também conhecidos como coasters, com impressões de rótulos de cervejas famosas'],
+  [copos_e_canecas, 'Copo Colapsável EcoOffice', 'Nunca mais fique sem copo no bebedouro de galão! Este copo de 300ml se contrai a um disco que cabe em qualquer bolso. Aproveite esta novidade!'],
+  [canecas, 'Codando Loucamente', 'Caneca com os dizeres "Talking is cheap, show me the code" em formatação de código'], 
+  [nil, 'Adesivos Grumpy Bear', 'Cartela de adesivos do Brown, o urso rabugento mais fofo que você conhece, e seu novo contatinho Cony a Coelha. Mas não conte pra ninguém que eles estão saindo, ainda é segredo!'], 
+  [vestuario, 'Fancy Napkings Silk Edition', 'Um lindo lenço branco rendado, em estilo vintage'], 
+  [utilidades_domesticas, 'Love Book - A Luz', 'Fofíssima luminária led para livros, com garra para prender na capa, em forma de coração (que você nunca vai usar mesmo porque o último livro que você leu foi para prestar vestibular)'], 
+  [cafe_e_cha, 'Pires Chá das 5', 'Pires de reposição para a Xícara Chá das 5'], 
+  [cafe_e_cha, 'Xícara Chá das 5', 'Elegante xícara em fina cerâmica, para momentos elegantes ao tomar chá ou café.'], 
+  [copos_e_canecas, 'Moonbucks', 'No melhor estilo das grandes lojas de café, este copo para bebidas quentes tem uma tampa de pequeno orifício, que permite tomar café em movimento sem se sujar.'], 
+  [canecas, 'Caneca Coffee Lovers', 'Eu moo, tu fazes o café, nós tomamos! Esta caneca não pode faltar na sua mesa de café da manhã!'], 
+  [garrafas_termicas, 'Caneca Térmica Hot Forever', 'Linda caneca térmica em aço inox, para compor um belo ambiente de trabalho na sua mesa de home office e ser ostentada furtivamente durante suas vídeo-conferências'], 
 ]
 
 brands = ['Pensaminarium', 'Vesúvia', 'TOC & ex-TOC']
 
-names_and_descriptions.each do | pair |
+names_and_descriptions.each do | info |
   Product.create(status: 'on_shelf',
-                name: pair[0], 
-                description: pair[1], 
+                product_category: info[0],
+                name: info[1], 
+                description: info[2], 
                 brand: brands[rand(brands.size)],
                 sku: ('a'..'z').to_a.shuffle[0..1].join.upcase + (SecureRandom.random_number * 10**7).to_i.to_s,
   ).set_price(14 * (1 + rand(100)/100.0).truncate(2))
@@ -104,7 +105,6 @@ CartItem.create!(product: product1, quantity: 5, user: user )
 CartItem.create!(product: product2, quantity: 7, user: user )
 Order.create!(address: 'Rua da entrega, 75', user: user)
 CartItem.create!(product: product3, quantity: 5, user: user )
-CartItem.create!(product: product1, quantity: 7, user: user )
 
 
 puts "\nSumário"

--- a/spec/system/product/anyone_searches_products_spec.rb
+++ b/spec/system/product/anyone_searches_products_spec.rb
@@ -51,5 +51,28 @@ feature 'Using the search function on the navbar,' do
 
       expect(page).to have_text('Nenhum resultado encontrado para: chocolate branco')
     end
+
+    it 'shows each result only once' do
+      product = create(:product, status: 'on_shelf', name: 'Pracha de surf',
+                                 description: 'Wetsuit para Surf', brand: 'Surf me')
+
+      visit root_path
+      fill_in 'Busque aqui seu produto', with: 'surf'
+      click_on 'Procurar'
+
+      expect(page).to have_text(product.name, count: 1)
+    end
+
+    it 'returns results orders by product name' do
+      product1 = create(:product, status: 'on_shelf', name: 'Pracha de surf')
+      product2 = create(:product, status: 'on_shelf', name: 'Surfaces and textures')
+      product3 = create(:product, status: 'on_shelf', name: 'Leash de Kitesurf')
+
+      visit root_path
+      fill_in 'Busque aqui seu produto', with: 'surf'
+      click_on 'Procurar'
+
+      expect(page.text.index('Leash de Kitesurf')).to be < page.text.index('Pracha de surf')
+    end
   end
 end


### PR DESCRIPTION
Conforme issue
- #42 
os produtos estavam aparecendo mais de uma vez se a palavra buscada aparecesse tanto no nome quanto na descrição do produto. Resolve isso.

Aproveita e também ordena pesquisa por ordem alfabética dos nomes dos produtos.

Aproveita e também melhora os Seeds pra eles incluírem categorias de produtos nos cacarecos criados.