### PR TITLE
Permite seeds rodar sem app Pagamentos disponível

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,6 @@
 class Order < ApplicationRecord
+  attr_accessor :skip_callback
+
   belongs_to :user
   has_many :cart_items
   validates_presence_of :address
@@ -6,9 +8,9 @@ class Order < ApplicationRecord
 
   before_create :set_code
   after_create :process_cart
-  after_create :request_payment
+  after_create :request_payment, unless: :skip_callback
 
-  enum status: {pending: 0, approved: 5, canceled: 9}
+  enum status: { pending: 0, approved: 5, canceled: 9 }
   
   private
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ puts "\n----- cria cadastros de usuários ------"
 
 Admin.create(email: 'claudia@mercadores.com.br', password: '123456', name: 'Claudia Ferreira')
 admin = Admin.create(email: 'manoel@mercadores.com.br', password: '123456', name: 'Manoel da Silva')
-user = User.create(email: 'joaquim@meuemail.com.br', password: '123456', name: 'Joaquim Santos', identify_number: '69907388041')
+user = User.create(email: 'joaquim@meuemail.com.br', password: '123456', name: 'Joaquim Santos', identify_number: '95350391216')
 
 puts '--------- cria taxa de câmbio ---------'
 
@@ -108,15 +108,22 @@ puts '----------- cria pedidos --------------'
 
 CartItem.create!(product: product1, quantity: 5, user: user )
 CartItem.create!(product: product2, quantity: 7, user: user )
-Order.create!(address: 'Rua da entrega, 75', user: user)
+order1 = Order.new(address: 'Rua da entrega, 75', user: user)
+order1.skip_callback = true
+order1.save!
 
 CartItem.create!(product: product3, quantity: 1, user: user )
 CartItem.create!(product: product4, quantity: 3, user: user )
-order = Order.create!(address: 'Rua da Paz, 42 - Belém, PA', user: user)
-order.approved!
+order2 = Order.new(address: 'Rua da Paz, 42 - Belém, PA', user: user)
+order2.skip_callback = true
+order2.save!
+order2.approved!
 
 CartItem.create!(product: product5, quantity: 6, user: user )
-order.update!(status: 'canceled', error_type: 'insufficient_funds')
+order3 = Order.new(address: 'Rua do Bailão de Domingo - Erechim, RS', user: user)
+order3.skip_callback = true
+order3.save!
+order3.update!(status: 'canceled', error_type: 'insufficient_funds')
 
 puts "\nSumário"
 puts "Foram criadas #{ExchangeRate.all.size} taxas de câmbio"


### PR DESCRIPTION
Como estava antes, a execução do Seeds era abortada se o app de Pagamentos não estivesse disponível.

Para evitar isso, adiciona um atributo `skip_callback` no model `Order` que pula a chamada de API caso ele esteja com valur `true`.