### PR TITLE
fix: Modifica parâmetro de procura para realizar patch pelo endpoint

### DIFF
--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::PaymentsController < Api::V1::ApiController
   rescue_from ActiveRecord::ActiveRecordError, with: :status_500
 
   def results
-    order = Order.find_by(code: params[:transaction][:code])
+    order = Order.find_by(transaction_code: params[:transaction][:code])
     status = params[:transaction][:status]
     error_type = params[:transaction][:error_type]
     return render json: 'Transação desconhecida.', status: :not_found if order.nil?

--- a/app/services/transaction.rb
+++ b/app/services/transaction.rb
@@ -36,7 +36,7 @@ class Transaction < ApplicationService
                 "client_transaction": { "credit_value": @value,
                                         "type_transaction": @transaction_type }
                 }.as_json
-    @response = Faraday.post(API_ROOT.concat(API_ENDPOINT), payload)
+    @response = Faraday.post(API_ROOT + API_ENDPOINT, payload)
     if @response.status == 201 && @order_id.present?
       Order.find(@order_id).update!(transaction_code: JSON.parse(@response.body)[API_VARIABLE_HOLDING_TRANSACTION_CODE])
     end

--- a/spec/requests/api/v1/payments_api_spec.rb
+++ b/spec/requests/api/v1/payments_api_spec.rb
@@ -3,12 +3,11 @@ require 'rails_helper'
 describe 'PATCH api/v1/payment_results' do 
   it 'when done correctly returns 200 with success message' do
     # below: mock for API call when creating an order
-    user = create(:user)
-
     fake_response = double('faraday_response', status: 201, 
                                                 body: '{ "transaction_code": "nsurg745n" }')
     allow(Faraday).to receive(:post).and_return(fake_response)
-
+      
+    user = create(:user)
     create(:cart_item, user: user)
     create(:order, status: 'pending', user: user) 
     order = Order.last
@@ -33,7 +32,6 @@ describe 'PATCH api/v1/payment_results' do
 
     user = create(:user)
     create(:cart_item, user: user)
-    allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('ASDF1234')
     create(:order, user: user)
     order = Order.last
 

--- a/spec/requests/api/v1/payments_api_spec.rb
+++ b/spec/requests/api/v1/payments_api_spec.rb
@@ -1,16 +1,17 @@
 require 'rails_helper'
 
 describe 'PATCH api/v1/payment_results' do 
-  # Mocks não estão escrevendo atributo "transaction_code" do pedido
   it 'when done correctly returns 200 with success message' do
     # below: mock for API call when creating an order
+    user = create(:user)
+
     fake_response = double('faraday_response', status: 201, 
                                                 body: '{ "transaction_code": "nsurg745n" }')
     allow(Faraday).to receive(:post).and_return(fake_response)
 
-    user = create(:user)
     create(:cart_item, user: user)
-    order = create(:order, status: 'pending', user: user, transaction_code: "nsurg745n")
+    create(:order, status: 'pending', user: user) 
+    order = Order.last
 
     patch '/api/v1/payment_results', params: { transaction: { "code": "#{order.transaction_code}",
                                                               "status": "canceled",
@@ -33,7 +34,8 @@ describe 'PATCH api/v1/payment_results' do
     user = create(:user)
     create(:cart_item, user: user)
     allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('ASDF1234')
-    order = create(:order, user: user)
+    create(:order, user: user)
+    order = Order.last
 
     patch '/api/v1/payment_results', params: { transaction: { "code": "asdgr654s",
                                                               "status": "approved",
@@ -53,7 +55,8 @@ describe 'PATCH api/v1/payment_results' do
     
     user = create(:user)
     create(:cart_item, user: user)
-    order = create(:order, status: 'pending', user: user, transaction_code: "nsurg745n")
+    create(:order, status: 'pending', user: user)
+    order = Order.last
 
     patch '/api/v1/payment_results', params: { transaction: { "code": "#{order.transaction_code}",
                                                               "status": "happy",
@@ -74,7 +77,8 @@ describe 'PATCH api/v1/payment_results' do
     
     user = create(:user)
     create(:cart_item, user: user)
-    order = create(:order, user: user, transaction_code: "nsurg745n")
+    create(:order, user: user)
+    order = Order.last
 
     patch '/api/v1/payment_results', params: { transaction: { "code": "#{order.transaction_code}",
                                                               "status": "canceled",

--- a/spec/requests/api/v1/payments_api_spec.rb
+++ b/spec/requests/api/v1/payments_api_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe 'PATCH api/v1/payment_results' do 
+  # Mocks não estão escrevendo atributo "transaction_code" do pedido
   it 'when done correctly returns 200 with success message' do
     # below: mock for API call when creating an order
     fake_response = double('faraday_response', status: 201, 
@@ -9,9 +10,9 @@ describe 'PATCH api/v1/payment_results' do
 
     user = create(:user)
     create(:cart_item, user: user)
-    order = create(:order, status: 'pending', user: user)
+    order = create(:order, status: 'pending', user: user, transaction_code: "nsurg745n")
 
-    patch '/api/v1/payment_results', params: { transaction: { "code": "#{order.code}",
+    patch '/api/v1/payment_results', params: { transaction: { "code": "#{order.transaction_code}",
                                                               "status": "canceled",
                                                               "error_type": "insufficient_funds" } }
     body = response.body
@@ -34,7 +35,7 @@ describe 'PATCH api/v1/payment_results' do
     allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('ASDF1234')
     order = create(:order, user: user)
 
-    patch '/api/v1/payment_results', params: { transaction: { "code": "4567-QWER",
+    patch '/api/v1/payment_results', params: { transaction: { "code": "asdgr654s",
                                                               "status": "approved",
                                                               "error_type": "" } }
     body = response.body
@@ -52,9 +53,9 @@ describe 'PATCH api/v1/payment_results' do
     
     user = create(:user)
     create(:cart_item, user: user)
-    order = create(:order, status: 'pending', user: user)
+    order = create(:order, status: 'pending', user: user, transaction_code: "nsurg745n")
 
-    patch '/api/v1/payment_results', params: { transaction: { "code": "#{order.code}",
+    patch '/api/v1/payment_results', params: { transaction: { "code": "#{order.transaction_code}",
                                                               "status": "happy",
                                                               "error_type": "" } }
     body = response.body
@@ -73,9 +74,9 @@ describe 'PATCH api/v1/payment_results' do
     
     user = create(:user)
     create(:cart_item, user: user)
-    order = create(:order, user: user)
-    
-    patch '/api/v1/payment_results', params: { transaction: { "code": "#{order.code}",
+    order = create(:order, user: user, transaction_code: "nsurg745n")
+
+    patch '/api/v1/payment_results', params: { transaction: { "code": "#{order.transaction_code}",
                                                               "status": "canceled",
                                                               "error_type": "" } }
     body = response.body
@@ -86,14 +87,9 @@ describe 'PATCH api/v1/payment_results' do
   end
 
   it 'returns 500 if some error occurs inside the server' do
-    # below: mock for API call when creating an order
-    fake_response = double('faraday_response', status: 201, 
-                                                body: '{ "transaction_code": "nsurg745n" }')
-    allow(Faraday).to receive(:post).and_return(fake_response)
-    
     allow(Order).to receive(:find_by).and_raise(ActiveRecord::ActiveRecordError)
 
-    patch '/api/v1/payment_results', params: { transaction: { "code": "4567-QWER",
+    patch '/api/v1/payment_results', params: { transaction: { "code": "nsurg745n",
                                                               "status": "completed",
                                                               "error_type": "" } }
     body = response.body

--- a/spec/system/order/user_views_order_details_spec.rb
+++ b/spec/system/order/user_views_order_details_spec.rb
@@ -23,7 +23,7 @@ describe 'User enters order detail page' do
     click_on "Detalhes do Pedido"
 
     expect(page).to have_content "#{price_in_rubis_at_time_of_purchase} #{3 * price_in_rubis_at_time_of_purchase}"
-    expect(page).not_to have_content "#{price_in_rubis_now}"
+    expect(page).not_to have_content "#{price_in_rubis_now} #{3 * price_in_rubis_now}"
   end
   
   it "and sees a message if the order was canceled due to insufficiente funds" do


### PR DESCRIPTION
* Pequena atualização do funcionamento do endpoint de patch de pedido: a busca na db é feita pelo código de transação gerado pela API de pagamentos